### PR TITLE
feat(charts): Add service monitor for cloudflare-tunnel

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -3,7 +3,6 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: Add ServiceMonitor support for Prometheus metrics
-    - bump cloudflared version to 2025.9.0
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository

--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -14,7 +14,7 @@ name: cloudflare-tunnel
 description: Creation of a cloudflared deployment - a reverse tunnel for an environment
 type: application
 
-version: "0.5.10"
+version: "0.5.11"
 # renovate: datasource=github-releases depName=cloudflare/cloudflared
 appVersion: "2025.5.0"
 

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,8 +1,10 @@
 # cloudflare-tunnel
 
-![Version: 0.5](https://img.shields.io/badge/Version-0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.1.0](https://img.shields.io/badge/AppVersion-2025.1.0-informational?style=flat-square)
+![Version: 0.5.11](https://img.shields.io/badge/Version-0.5.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.5.0](https://img.shields.io/badge/AppVersion-2025.5.0-informational?style=flat-square)
 
 Creation of a cloudflared deployment - a reverse tunnel for an environment
+
+**Homepage:** <https://github.com/lexfrei/charts/>
 
 ## Maintainers
 
@@ -42,4 +44,5 @@ Creation of a cloudflared deployment - a reverse tunnel for an environment
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Security items for one container. We lock it down |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.enabled | bool | `false` | Enable prometheus Service Monitor |
 | tolerations | list | `[]` |  |

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.5.11](https://img.shields.io/badge/Version-0.5.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.5.0](https://img.shields.io/badge/AppVersion-2025.5.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.9.0](https://img.shields.io/badge/AppVersion-2025.9.0-informational?style=flat-square)
 
 Creation of a cloudflared deployment - a reverse tunnel for an environment
 
@@ -45,4 +45,8 @@ Creation of a cloudflared deployment - a reverse tunnel for an environment
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.enabled | bool | `false` | Enable prometheus Service Monitor |
+| serviceMonitor.interval | string | `""` | Scrape interval for Prometheus |
+| serviceMonitor.jobLabel | string | `""` | Job label for the ServiceMonitor |
+| serviceMonitor.metricRelabelings | list | `[]` | Metric relabelings for the ServiceMonitor |
+| serviceMonitor.relabelings | list | `[]` | Relabelings for the ServiceMonitor |
 | tolerations | list | `[]` |  |

--- a/charts/cloudflare-tunnel/templates/service.yaml
+++ b/charts/cloudflare-tunnel/templates/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudflare-tunnel.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 2000
+      targetPort: 2000
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "cloudflare-tunnel.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/cloudflare-tunnel/templates/servicemonitor.yaml
+++ b/charts/cloudflare-tunnel/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cloudflare-tunnel.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
+spec:
+  jobLabel: {{ .Values.serviceMonitor.jobLabel | quote }}
+  selector:
+    matchLabels:
+      {{- include "cloudflare-tunnel.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  - port: metrics
+    {{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/cloudflare-tunnel/templates/servicemonitor.yaml
+++ b/charts/cloudflare-tunnel/templates/servicemonitor.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.serviceMonitor.jobLabel }}
   jobLabel: {{ .Values.serviceMonitor.jobLabel | quote }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "cloudflare-tunnel.selectorLabels" . | nindent 6 }}
@@ -20,10 +22,10 @@ spec:
     {{- end }}
     {{- if .Values.serviceMonitor.metricRelabelings }}
     metricRelabelings:
-    {{ toYaml .Values.serviceMonitor.metricRelabelings | indent 4 }}
+      {{- toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
     {{- end }}
     {{- if .Values.serviceMonitor.relabelings }}
     relabelings:
-    {{ toYaml .Values.serviceMonitor.relabelings | indent 4 }}
+      {{- toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/charts/cloudflare-tunnel/values.schema.json
+++ b/charts/cloudflare-tunnel/values.schema.json
@@ -156,6 +156,31 @@
     },
     "affinity": {
       "type": "object"
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable prometheus Service Monitor."
+        },
+        "jobLabel": {
+          "type": "string",
+          "description": "Job label for the ServiceMonitor."
+        },
+        "interval": {
+          "type": "string",
+          "description": "Scrape interval for Prometheus."
+        },
+        "metricRelabelings": {
+          "type": "array",
+          "description": "Metric relabelings for the ServiceMonitor."
+        },
+        "relabelings": {
+          "type": "array",
+          "description": "Relabelings for the ServiceMonitor."
+        }
+      }
     }
   },
   "required": [

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -84,3 +84,7 @@ tolerations: []
 
 # -- Default affinity is to spread out over nodes; use this to override
 affinity: {}
+
+serviceMonitor:
+  # -- Enable prometheus Service Monitor
+  enabled: false

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -88,3 +88,11 @@ affinity: {}
 serviceMonitor:
   # -- Enable prometheus Service Monitor
   enabled: false
+  # -- Job label for the ServiceMonitor
+  jobLabel: ""
+  # -- Scrape interval for Prometheus
+  interval: ""
+  # -- Metric relabelings for the ServiceMonitor
+  metricRelabelings: []
+  # -- Relabelings for the ServiceMonitor
+  relabelings: []


### PR DESCRIPTION
I am creating this PR, in order to add the ability of exporting metrics to prometheus.

Cloudflare has a metrics endpoint in port 2000. With this change we can enable that option