### PR TITLE
feat: Add DaemonSet deployment mode

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -2,17 +2,9 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |
     - kind: added
-      description: Add originRequest configuration for upstream connection tuning
-    - kind: added
-      description: Add customizable liveness probe parameters
-    - kind: added
-      description: Add log level configuration via TUNNEL_LOGLEVEL
-    - kind: added
-      description: Add podLabels for custom pod labels
-    - kind: added
-      description: Add configurable metrics port (closes #14)
+      description: Add DaemonSet deployment mode as alternative to Deployment
     - kind: changed
-      description: Make metrics port configurable across all templates
+      description: Support for one tunnel pod per node to prevent port exhaustion
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -25,7 +17,7 @@ name: cloudflare-tunnel
 description: Creation of a cloudflared deployment - a reverse tunnel for an environment
 type: application
 
-version: "0.8.0"
+version: "0.9.0"
 # renovate: datasource=github-releases depName=cloudflare/cloudflared
 appVersion: "2025.9.0"
 

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.9.0](https://img.shields.io/badge/AppVersion-2025.9.0-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.9.0](https://img.shields.io/badge/AppVersion-2025.9.0-informational?style=flat-square)
 
 Creation of a cloudflared deployment - a reverse tunnel for an environment
 
@@ -32,6 +32,7 @@ Creation of a cloudflared deployment - a reverse tunnel for an environment
 | cloudflare.secretName | string | `nil` | If defined, no secret is created for the credentials, and instead, the secret referenced is used |
 | cloudflare.tunnelId | string | `""` | The ID of the above tunnel |
 | cloudflare.tunnelName | string | `""` | The name of the tunnel this instance will serve |
+| deploymentMode | string | `"deployment"` | Deployment mode: "deployment" or "daemonset" DaemonSet mode ensures one tunnel pod per node, useful for: - Preventing port exhaustion from multiple pods on same node - Following Cloudflare's recommendation to limit instances per node - Ensuring predictable distribution and node-level reliability |
 | fullnameOverride | string | `""` |  |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"cloudflare/cloudflared","tag":""}` | The image to use |
 | image.tag | string | `""` | If supplied, this overrides "appVersion" |

--- a/charts/cloudflare-tunnel/templates/daemonset.yaml
+++ b/charts/cloudflare-tunnel/templates/daemonset.yaml
@@ -1,21 +1,20 @@
-{{- if eq .Values.deploymentMode "deployment" }}
-# Here we deploy cloudflared images. The tunnel credentials are stored in
-# a k8s secret, and the configuration is stored in a k8s configmap.
+{{- if eq .Values.deploymentMode "daemonset" }}
+# DaemonSet ensures one cloudflared pod per node
+# Useful for preventing port exhaustion and following Cloudflare recommendations
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ include "cloudflare-tunnel.fullname" . }}
   labels:
     {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "cloudflare-tunnel.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
-        # These are here so the deployment rolls when the config or secret change.
+        # These are here so the daemonset rolls when the config or secret change.
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
@@ -93,30 +92,12 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-        {{- with .Values.affinity }}
         {{- toYaml . | nindent 8 }}
-        {{- else }}
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 10
-              podAffinityTerm:
-                topologyKey: kubernetes.io/hostname
-                labelSelector:
-                  matchExpressions:
-                  {{- range $k, $v := include "cloudflare-tunnel.selectorLabels" . | fromYaml }}
-                    - key: {{ $k }}
-                      operator: In
-                      values:
-                        - {{ $v }}
-                  {{- end }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
-      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/cloudflare-tunnel/tests/daemonset_mode_test.yaml
+++ b/charts/cloudflare-tunnel/tests/daemonset_mode_test.yaml
@@ -1,0 +1,206 @@
+suite: test DaemonSet deployment mode
+templates:
+  - deployment.yaml
+  - daemonset.yaml
+  - configmap.yaml
+  - secret.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: should create Deployment by default
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+    asserts:
+      - template: deployment.yaml
+        hasDocuments:
+          count: 1
+      - template: daemonset.yaml
+        hasDocuments:
+          count: 0
+
+  - it: should create DaemonSet when deploymentMode is daemonset
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+    asserts:
+      - template: daemonset.yaml
+        hasDocuments:
+          count: 1
+      - template: deployment.yaml
+        hasDocuments:
+          count: 0
+
+  - it: should use correct kind for DaemonSet
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: kind
+          value: DaemonSet
+
+  - it: should have all required fields in DaemonSet
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+    asserts:
+      - template: daemonset.yaml
+        isNotNull:
+          path: metadata.name
+      - template: daemonset.yaml
+        isNotNull:
+          path: spec.selector
+      - template: daemonset.yaml
+        isNotNull:
+          path: spec.template
+
+  - it: should support nodeSelector in DaemonSet mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+      nodeSelector:
+        disktype: ssd
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+
+  - it: should support tolerations in DaemonSet mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Exists
+          effect: NoSchedule
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: node-role.kubernetes.io/master
+            operator: Exists
+            effect: NoSchedule
+
+  - it: should support affinity in DaemonSet mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - node1
+    asserts:
+      - template: daemonset.yaml
+        isNotNull:
+          path: spec.template.spec.affinity.nodeAffinity
+
+  - it: should support custom pod labels in DaemonSet mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+      podLabels:
+        custom-label: custom-value
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.metadata.labels["custom-label"]
+          value: custom-value
+
+  - it: should support priorityClassName in DaemonSet mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+      priorityClassName: high-priority
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.priorityClassName
+          value: high-priority
+
+  - it: should ignore replicaCount in DaemonSet mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+      replicaCount: 5
+    asserts:
+      - template: daemonset.yaml
+        isNull:
+          path: spec.replicas

--- a/charts/cloudflare-tunnel/values.schema.json
+++ b/charts/cloudflare-tunnel/values.schema.json
@@ -330,6 +330,12 @@
     "podLabels": {
       "type": "object",
       "description": "Additional labels to add to pods."
+    },
+    "deploymentMode": {
+      "type": "string",
+      "description": "Deployment mode: deployment or daemonset.",
+      "enum": ["deployment", "daemonset"],
+      "default": "deployment"
     }
   },
   "required": [

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -158,3 +158,10 @@ logLevel: ""
 
 # -- Additional labels to add to pods
 podLabels: {}
+
+# -- Deployment mode: "deployment" or "daemonset"
+# DaemonSet mode ensures one tunnel pod per node, useful for:
+# - Preventing port exhaustion from multiple pods on same node
+# - Following Cloudflare's recommendation to limit instances per node
+# - Ensuring predictable distribution and node-level reliability
+deploymentMode: deployment


### PR DESCRIPTION
Closes #28

## Description
Adds support for deploying cloudflared as a DaemonSet instead of a Deployment, providing better control over pod distribution and preventing port exhaustion issues.

## Implementation (TDD Approach)

### ✅ Phase 1: Test Setup (RED)
- Created comprehensive test suite with 10 test cases
- All tests initially failed as expected

### ✅ Phase 2: Implementation (GREEN)
- Added `deploymentMode` parameter (default: "deployment")
- Created `templates/daemonset.yaml` with full feature parity
- Added conditional rendering logic
- All 105 tests now passing

### ✅ Phase 3: Documentation & Polish
- Updated Chart.yaml to version 0.9.0
- Generated updated README.md
- Updated values.schema.json
- All lint checks passing

## Features

### DaemonSet Mode Benefits
- **Port exhaustion prevention**: One pod per node prevents ephemeral port conflicts
- **Cloudflare recommendation**: Follows official guidance to limit instances per node
- **Predictable distribution**: Ensures exactly one tunnel per node
- **Node-level reliability**: Each node gets its own tunnel connection

### Feature Parity
DaemonSet mode supports all existing features:
- ✅ nodeSelector
- ✅ tolerations
- ✅ affinity
- ✅ podLabels
- ✅ priorityClassName
- ✅ securityContext
- ✅ resources
- ✅ liveness probes
- ✅ log levels
- ✅ metrics configuration

## Usage

```yaml
# Deploy as DaemonSet (one pod per node)
deploymentMode: daemonset

# Or keep default Deployment mode
deploymentMode: deployment  # default
```

## Testing

- ✅ All 105 tests passing
- ✅ Helm lint successful
- ✅ Full backward compatibility maintained
- ✅ No breaking changes

## Breaking Changes

None - completely backward compatible. Default behavior unchanged.