### PR TITLE
fix: add skip_existing to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,5 +25,7 @@ jobs:
 
       - name: Release charts
         uses: helm/chart-releaser-action@v1.7.0
+        with:
+          skip_existing: true
         env:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Fix publish workflow failures when re-releasing existing chart versions.

## Type of change
- [x] Bug fix

## Problem
Publish workflow fails with 'tag already exists' error when:
- Multiple charts are packaged
- Only some charts have version changes
- Trying to re-release unchanged charts

## Solution
Added `skip_existing: true` to chart-releaser-action which skips upload if release already exists.

## Checklist
- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code