### PR TITLE
feat: automate chart version bump and changelog updates

### DIFF
--- a/.github/workflows/renovate-changelog.yaml
+++ b/.github/workflows/renovate-changelog.yaml
@@ -1,0 +1,72 @@
+name: Update Renovate PR Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'charts/**/Chart.yaml'
+
+jobs:
+  update-changelog:
+    # Only run on Renovate PRs
+    if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Update changelog for changed charts
+        id: update
+        run: |
+          set -e
+          CHARTS_UPDATED=false
+          
+          # Find all changed Chart.yaml files
+          for chart_file in $(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep 'Chart.yaml$' || true); do
+            echo "Processing $chart_file"
+            
+            # Extract chart directory
+            chart_dir=$(dirname "$chart_file")
+            
+            # Get the new appVersion from the PR
+            new_app_version=$(yq eval '.appVersion' "$chart_file")
+            chart_version=$(yq eval '.version' "$chart_file")
+            
+            echo "Chart: $chart_dir"
+            echo "Version: $chart_version"
+            echo "AppVersion: $new_app_version"
+            
+            # Update changelog annotation using yq
+            yq eval -i '.annotations."artifacthub.io/changes" = "- kind: changed\n  description: Update appVersion to '"$new_app_version"'"' "$chart_file"
+            
+            CHARTS_UPDATED=true
+          done
+          
+          echo "charts_updated=$CHARTS_UPDATED" >> $GITHUB_OUTPUT
+
+      - name: Commit changes
+        if: steps.update.outputs.charts_updated == 'true'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          
+          git add charts/**/Chart.yaml
+          
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: update changelog annotations [skip ci]"
+            git push
+          fi

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,20 @@
   "extends": [
     "config:recommended"
   ],
+  "packageRules": [
+    {
+      "description": "Auto-bump chart version when appVersion changes",
+      "matchManagers": ["regex"],
+      "matchFiles": ["charts/**/Chart.yaml"],
+      "bumpVersions": [
+        {
+          "filePatterns": ["{{{packageFileDir}}}/Chart.{yaml,yml}"],
+          "matchStrings": ["version:\\s+[\"']?(?<version>[^\"'\\s]+)[\"']?"],
+          "bumpType": "{{#if isPatch}}patch{{else}}minor{{/if}}"
+        }
+      ]
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": [


### PR DESCRIPTION
## Description
Automates chart version bumping and changelog updates when Renovate updates appVersion.

## Changes

### 1. Renovate bumpVersions config
- Automatically bumps chart version when appVersion changes
- Patch bump for patch updates
- Minor bump for minor/major updates

### 2. GitHub Action for changelog
- Triggers on Renovate PRs
- Uses yq to update artifacthub.io/changes annotation
- Commits changelog with the new appVersion

## How it works

1. Renovate creates PR to update appVersion
2. Renovate automatically bumps chart version (via bumpVersions)
3. GitHub Action detects Renovate PR
4. Action updates changelog annotation with new appVersion
5. Action commits changes back to PR

## Benefits
- No more manual version bumps!
- No more manual changelog updates!
- Consistent changelog format
- Less maintenance overhead

## Testing needed
Will need to test with actual Renovate PR to verify workflow permissions.

## Checklist
- [x] Added bumpVersions to renovate.json
- [x] Created GitHub Action workflow
- [x] Uses yq for YAML manipulation
- [x] Includes [skip ci] to avoid infinite loops