### PR TITLE
fix: force clean working directory before gh-pages checkout

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -214,8 +214,9 @@ jobs:
 
       - name: Update index
         run: |
-          # Remove local index.yaml if exists to avoid conflicts
-          rm -f index.yaml
+          # Force clean working directory before checkout
+          git reset --hard HEAD
+          git clean -fdx
           
           git checkout gh-pages
           helm repo index . --url https://lexfrei.github.io/charts


### PR DESCRIPTION
## Problem

The workflow was failing to update the Helm repository index in the `gh-pages` branch because `chart-releaser` creates local files (including `index.yaml`) that prevent git from switching branches.

### Error
```
error: The following untracked working tree files would be overwritten by checkout:
  index.yaml
Please move or remove them before you switch branches.
Aborting
```

This caused all releases after version 0.5.4 (0.5.5 through 0.9.2) to be published on GitHub Releases but not included in the Helm repository index.

## Solution

Use `git reset --hard HEAD` and `git clean -fdx` to force clean the working directory before checking out the `gh-pages` branch. This ensures no untracked files interfere with the branch switch.

## Impact

- Fixes the broken index update process
- Future releases will be properly added to the Helm repository index
- After merging, a manual workflow run or new chart version will rebuild the index with all missing versions