### PR TITLE
feat(cloudflare-tunnel): update documentation to clarify official image usage

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -3,8 +3,8 @@ annotations:
   # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
   # See: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix Artifact Hub badge link to point to correct package URL
+    - kind: changed
+      description: Update documentation to clarify usage of official Cloudflare image
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -17,7 +17,7 @@ name: cloudflare-tunnel
 description: Creation of a cloudflared deployment - a reverse tunnel for an environment
 type: application
 
-version: "0.9.2"
+version: "0.9.3"
 # renovate: datasource=github-releases depName=cloudflare/cloudflared
 appVersion: "2025.9.0"
 

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.9.0](https://img.shields.io/badge/AppVersion-2025.9.0-informational?style=flat-square)
+![Version: 0.9.3](https://img.shields.io/badge/Version-0.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.9.0](https://img.shields.io/badge/AppVersion-2025.9.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -13,6 +13,8 @@
 Creation of a cloudflared deployment - a reverse tunnel for an environment
 
 **Homepage:** <https://github.com/lexfrei/charts/>
+
+> **Note**: This chart uses the official Cloudflare Docker image [`cloudflare/cloudflared`](https://hub.docker.com/r/cloudflare/cloudflared) maintained by Cloudflare.
 
 ## ✨ Features
 
@@ -32,6 +34,14 @@ Creation of a cloudflared deployment - a reverse tunnel for an environment
 - Implement Zero Trust network architecture
 - Connect on-premises services to Cloudflare's network
 - Enable secure remote access without VPNs
+
+## 🐳 Docker Image
+
+This Helm chart uses the **official Cloudflare Docker image**:
+- **Image**: [`cloudflare/cloudflared`](https://hub.docker.com/r/cloudflare/cloudflared)
+- **Maintained by**: Cloudflare
+- **Auto-updated**: Via Renovate bot to track latest releases
+- **Source**: [github.com/cloudflare/cloudflared](https://github.com/cloudflare/cloudflared)
 
 ## 📋 Prerequisites
 

--- a/charts/cloudflare-tunnel/README.md.gotmpl
+++ b/charts/cloudflare-tunnel/README.md.gotmpl
@@ -16,6 +16,8 @@
 
 {{ template "chart.homepageLine" . }}
 
+> **Note**: This chart uses the official Cloudflare Docker image [`cloudflare/cloudflared`](https://hub.docker.com/r/cloudflare/cloudflared) maintained by Cloudflare.
+
 ## ✨ Features
 
 - 🚀 **Zero Trust Network Access** - Secure remote access to your Kubernetes services without exposing them to the internet
@@ -34,6 +36,14 @@
 - Implement Zero Trust network architecture
 - Connect on-premises services to Cloudflare's network
 - Enable secure remote access without VPNs
+
+## 🐳 Docker Image
+
+This Helm chart uses the **official Cloudflare Docker image**:
+- **Image**: [`cloudflare/cloudflared`](https://hub.docker.com/r/cloudflare/cloudflared)
+- **Maintained by**: Cloudflare
+- **Auto-updated**: Via Renovate bot to track latest releases
+- **Source**: [github.com/cloudflare/cloudflared](https://github.com/cloudflare/cloudflared)
 
 ## 📋 Prerequisites
 


### PR DESCRIPTION
## Changes

### Documentation Updates
- Added **Docker Image** section to README highlighting the use of official Cloudflare image
- Clarified that this chart uses `cloudflare/cloudflared` from Docker Hub
- Added note that the image is maintained by Cloudflare
- Mentioned auto-updates via Renovate bot

### Chart Updates
- Bumped chart version to **0.9.3**
- Updated changelog to reflect documentation improvements

## Why?

Users should know that this chart uses the official, Cloudflare-maintained Docker image rather than a community or third-party image. This provides assurance about:
- Image quality and security
- Regular updates and maintenance
- Official support from Cloudflare

## Impact

- Better transparency for users
- Clearer documentation
- No functional changes to the chart itself