### PR TITLE
fix: resolve gh-pages push conflicts in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -219,6 +219,7 @@ jobs:
           git clean -fdx
           
           git checkout gh-pages
+          git pull --rebase origin gh-pages
           helm repo index . --url https://lexfrei.github.io/charts
           git add index.yaml
           git commit -m "Update Helm index" || echo "No changes to commit"


### PR DESCRIPTION
## Problem

The publish workflow fails with `non-fast-forward` error when pushing to gh-pages because:
1. chart-releaser updates gh-pages first
2. Then "Update index" step tries to push again without pulling the latest changes

## Solution

Added `git pull --rebase origin gh-pages` before pushing to ensure we have the latest changes.

## Testing

This should fix the publish workflow failure that occurred after merging PR #47.