### PR TITLE
feat: add automatic documentation generation for Renovate PRs

### DIFF
--- a/.github/workflows/renovate-docs.yaml
+++ b/.github/workflows/renovate-docs.yaml
@@ -1,0 +1,69 @@
+name: Update Renovate PR Documentation
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'charts/**/Chart.yaml'
+
+jobs:
+  update-docs:
+    # Only run on Renovate PRs
+    if: startsWith(github.head_ref, 'renovate/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install helm-docs
+        run: |
+          HELM_DOCS_VERSION="1.14.2"
+          wget -q https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz
+          tar -xzf helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz
+          sudo mv helm-docs /usr/local/bin/
+          sudo chmod +x /usr/local/bin/helm-docs
+
+      - name: Generate documentation for changed charts
+        id: generate
+        run: |
+          set -e
+          DOCS_UPDATED=false
+          
+          # Find all changed Chart.yaml files
+          for chart_file in $(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep 'Chart.yaml$' || true); do
+            chart_dir=$(dirname "$chart_file")
+            
+            # Check if README.md.gotmpl exists
+            if [ -f "$chart_dir/README.md.gotmpl" ]; then
+              echo "Generating documentation for $chart_dir"
+              helm-docs "$chart_dir"
+              DOCS_UPDATED=true
+            else
+              echo "No README.md.gotmpl found in $chart_dir, skipping"
+            fi
+          done
+          
+          echo "docs_updated=$DOCS_UPDATED" >> $GITHUB_OUTPUT
+
+      - name: Commit changes
+        if: steps.generate.outputs.docs_updated == 'true'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          
+          git add charts/**/README.md
+          
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "docs: update README.md with helm-docs [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
## Description
Adds automatic helm-docs generation for Renovate PRs to keep README.md in sync with Chart.yaml changes.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## Additional context
When Renovate updates appVersion in Chart.yaml, the README.md needs to be regenerated via helm-docs. This workflow automates that process.