### PR TITLE
fix: remove [skip ci] and prevent workflow cycles in renovate-update

### DIFF
--- a/.github/workflows/renovate-update.yaml
+++ b/.github/workflows/renovate-update.yaml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   update-renovate-pr:
-    # Only run on Renovate PRs
-    if: startsWith(github.head_ref, 'renovate/')
+    # Only run on Renovate PRs, but not on commits from github-actions bot
+    if: startsWith(github.head_ref, 'renovate/') && github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -89,6 +89,6 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "chore: update changelog and documentation [skip ci]"
+            git commit -m "chore: update changelog and documentation"
             git push
           fi


### PR DESCRIPTION
## Description
Fixes the renovate workflow to allow tests to run after changelog/documentation updates while preventing infinite workflow cycles.

**Changes:**
- Remove `[skip ci]` from commit messages to allow tests to run
- Add `github.actor != 'github-actions[bot]'` condition to prevent workflow from running on its own commits

**Problem:** 
- `[skip ci]` prevented tests from running after changelog updates
- This could cause PRs to not get proper test validation
- Branch protection rules might fail

**Solution:**
- Tests will now run after bot updates changelog and docs  
- Workflow cycles are prevented by actor check
- Proper validation of all changes before merge

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code