### PR TITLE
fix: trigger tests after renovate bot commits

### DIFF
--- a/.github/workflows/renovate-update.yaml
+++ b/.github/workflows/renovate-update.yaml
@@ -92,3 +92,19 @@ jobs:
             git commit -m "chore: update changelog and documentation"
             git push
           fi
+
+      - name: Trigger tests after bot commit
+        if: steps.update.outputs.changes_made == 'true'
+        run: |
+          # Get list of changed charts from the update step
+          changed_charts=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep 'Chart.yaml
+ | sed 's|/Chart.yaml||' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          
+          echo "Triggering tests for charts: $changed_charts"
+          
+          # Trigger the test workflow with the changed charts
+          gh workflow run test.yaml \
+            --ref ${{ github.head_ref }} \
+            --field charts="$changed_charts"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,12 @@ on:
       - master
     paths:
       - 'charts/**'
+  workflow_dispatch:
+    inputs:
+      charts:
+        description: 'JSON array of chart paths to test (optional)'
+        required: false
+        type: string
 
 jobs:
   detect-changes:
@@ -29,16 +35,25 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
 
-      - name: Run chart-testing (list-changed)
+      - name: Run chart-testing (list-changed) or use manual input
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs charts)
-          if [[ -n "$changed" ]]; then
-            # Convert newline-separated list to JSON array
-            charts_json=$(echo "$changed" | jq -R -s -c 'split("\n") | map(select(length > 0))')
-            echo "charts=$charts_json" >> "$GITHUB_OUTPUT"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.charts }}" ]]; then
+            # Use manually provided charts list
+            echo "charts=${{ inputs.charts }}" >> "$GITHUB_OUTPUT"
+            echo "Using manually provided charts: ${{ inputs.charts }}"
           else
-            echo "charts=[]" >> "$GITHUB_OUTPUT"
+            # Auto-detect changed charts
+            changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs charts)
+            if [[ -n "$changed" ]]; then
+              # Convert newline-separated list to JSON array
+              charts_json=$(echo "$changed" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+              echo "charts=$charts_json" >> "$GITHUB_OUTPUT"
+              echo "Auto-detected changed charts: $charts_json"
+            else
+              echo "charts=[]" >> "$GITHUB_OUTPUT"
+              echo "No changed charts detected"
+            fi
           fi
 
   lint-test:


### PR DESCRIPTION
## Description
Adds ability to trigger tests after renovate bot commits to ensure proper CI validation.

**Problem:** 
- Tests don't run after renovate bot commits due to GITHUB_TOKEN limitation
- PRs remain without proper test validation
- Branch protection rules may fail

**Solution:**
- Add `workflow_dispatch` to test.yaml with optional charts parameter
- Add step in renovate-update.yaml to trigger tests after bot commits
- Use GitHub API to programmatically start test workflow
- Pass specific changed charts to optimize test execution

**Changes:**
1. **test.yaml**: Added `workflow_dispatch` trigger with charts input parameter
2. **renovate-update.yaml**: Added step to trigger tests via `gh workflow run`

**Security:** Uses GITHUB_TOKEN (no additional permissions needed)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

## Testing
After merging, renovate bot commits should automatically trigger test workflows, ensuring proper validation of all changes before PR completion.