### PR TITLE
fix: improve workflow_dispatch JSON handling and add validation

### DIFF
--- a/.github/workflows/renovate-update.yaml
+++ b/.github/workflows/renovate-update.yaml
@@ -101,9 +101,15 @@ jobs:
           
           echo "Triggering tests for charts: $changed_charts"
           
-          # Trigger the test workflow with the changed charts
-          gh workflow run test.yaml \
-            --ref ${{ github.head_ref }} \
-            --field charts="$changed_charts"
+          # Only trigger if we have charts to test
+          if [[ "$changed_charts" != "[]" ]]; then
+            # Trigger the test workflow with the changed charts
+            gh workflow run test.yaml \
+              --ref ${{ github.head_ref }} \
+              --field charts="$changed_charts"
+            echo "✅ Test workflow triggered successfully"
+          else
+            echo "ℹ️ No charts to test, skipping workflow trigger"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,9 +39,16 @@ jobs:
         id: list-changed
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.charts }}" ]]; then
-            # Use manually provided charts list
-            echo "charts=${{ inputs.charts }}" >> "$GITHUB_OUTPUT"
-            echo "Using manually provided charts: ${{ inputs.charts }}"
+            # Use manually provided charts list (parse JSON string)
+            charts_input="${{ inputs.charts }}"
+            # Validate JSON and use as-is since it should already be a JSON array
+            if echo "$charts_input" | jq . >/dev/null 2>&1; then
+              echo "charts=$charts_input" >> "$GITHUB_OUTPUT"
+              echo "Using manually provided charts: $charts_input"
+            else
+              echo "charts=[]" >> "$GITHUB_OUTPUT"
+              echo "Invalid JSON provided in charts input: $charts_input"
+            fi
           else
             # Auto-detect changed charts
             changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs charts)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,14 +40,17 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.charts }}" ]]; then
             # Use manually provided charts list (parse JSON string)
-            charts_input="${{ inputs.charts }}"
-            # Validate JSON and use as-is since it should already be a JSON array
-            if echo "$charts_input" | jq . >/dev/null 2>&1; then
-              echo "charts=$charts_input" >> "$GITHUB_OUTPUT"
-              echo "Using manually provided charts: $charts_input"
+            charts_input='${{ inputs.charts }}'
+            echo "Raw input received: $charts_input"
+
+            # Validate JSON and normalize it
+            if charts_json=$(echo "$charts_input" | jq -c '.' 2>/dev/null); then
+              echo "charts=$charts_json" >> "$GITHUB_OUTPUT"
+              echo "Using manually provided charts: $charts_json"
             else
               echo "charts=[]" >> "$GITHUB_OUTPUT"
               echo "Invalid JSON provided in charts input: $charts_input"
+              echo "Setting charts to empty array"
             fi
           else
             # Auto-detect changed charts

--- a/test-workflow.sh
+++ b/test-workflow.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Скрипт для локального тестирования workflow логики
+
+set -e
+
+echo "🧪 Локальное тестирование workflow логики"
+echo "========================================="
+
+# Тест 1: Проверка JSON валидации
+echo
+echo "🔍 Тест 1: JSON валидация"
+test_json='["charts/transmission"]'
+if echo "$test_json" | jq . >/dev/null 2>&1; then
+    echo "✅ JSON валиден: $test_json"
+    parsed=$(echo "$test_json" | jq -r '.[]')
+    echo "   Parsed: $parsed"
+else
+    echo "❌ JSON невалиден: $test_json"
+fi
+
+# Тест 2: Проверка формирования JSON из путей
+echo
+echo "🔍 Тест 2: Формирование JSON массива"
+mock_paths="charts/transmission/Chart.yaml
+charts/cloudflare-tunnel/Chart.yaml"
+
+echo "Mock paths:"
+echo "$mock_paths"
+
+charts_array=$(echo "$mock_paths" | grep 'Chart.yaml$' | sed 's|/Chart.yaml||' | jq -R -s -c 'split("\n") | map(select(length > 0))')
+echo "✅ Результат: $charts_array"
+
+# Тест 3: Проверка пустого результата
+echo
+echo "🔍 Тест 3: Пустой результат"
+empty_result=$(echo "" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+echo "✅ Пустой результат: $empty_result"
+
+# Тест 4: Проверка YAML синтаксиса (если yq установлен)
+echo
+echo "🔍 Тест 4: Проверка YAML файлов"
+for workflow in .github/workflows/*.yaml; do
+    if command -v yq >/dev/null 2>&1; then
+        if yq eval . "$workflow" >/dev/null 2>&1; then
+            echo "✅ $workflow - YAML синтаксис корректен"
+        else
+            echo "❌ $workflow - YAML синтаксис некорректен"
+        fi
+    else
+        echo "⚠️  yq не установлен, пропуск проверки YAML"
+        break
+    fi
+done
+
+echo
+echo "🎉 Все тесты завершены!"
+echo
+echo "💡 Для тестирования с act (если установлен):"
+echo "   act workflow_dispatch -W .github/workflows/test.yaml --input charts='[\"charts/transmission\"]'"
+echo
+echo "💡 Для проверки workflow синтаксиса онлайн:"
+echo "   https://rhysd.github.io/actionlint/"


### PR DESCRIPTION
## Description
Fixes the workflow_dispatch JSON input parsing issue in the test workflow that was causing the lint-test job to be skipped.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Problem
The workflow_dispatch functionality was failing because:
- JSON input with quotes wasn't being parsed correctly due to escaping issues
- The `charts` output wasn't being properly set in GITHUB_OUTPUT
- The `lint-test` job was being skipped due to the condition `needs.detect-changes.outputs.charts != '[]'` failing

## Solution
- **Fixed quote handling**: Changed from double quotes to single quotes around `${{ inputs.charts }}` to avoid escaping issues
- **Added debug logging**: Now shows the raw input received for troubleshooting
- **Improved JSON validation**: Uses `jq -c '.'` to normalize and validate JSON properly
- **Ensured output is always set**: The charts output is now always set, either with valid JSON or empty array

## Changes Made
- Modified the JSON input parsing logic in `.github/workflows/test.yaml`
- Added debugging output to help troubleshoot future issues
- Improved error handling for invalid JSON inputs

## Testing
- Locally tested JSON parsing with various inputs
- Verified chart linting works correctly
- The fix ensures workflow_dispatch events with JSON chart inputs will work properly

## Additional context
This resolves the issue where manually triggering the test workflow with specific charts via workflow_dispatch would only run the detect-changes job but skip the lint-test job.

🤖 Generated with [Claude Code](https://claude.ai/code)