### PR TITLE
feat(system-upgrade-controller): add new Helm chart with TDD and OCI publishing

### DIFF
--- a/.github/workflows/publish-system-upgrade-controller.yaml
+++ b/.github/workflows/publish-system-upgrade-controller.yaml
@@ -1,0 +1,230 @@
+name: Publish system-upgrade-controller to GHCR
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'charts/system-upgrade-controller/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write      # Create releases
+  packages: write      # Push to GHCR
+  id-token: write      # Keyless signing with OIDC
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
+      - name: Install helm-unittest plugin
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+
+      - name: Install check-jsonschema
+        run: pip install check-jsonschema
+
+      - name: Get chart version
+        id: chart-version
+        run: |
+          CHART_VERSION=$(yq eval '.version' charts/system-upgrade-controller/Chart.yaml)
+          CHART_NAME=$(yq eval '.name' charts/system-upgrade-controller/Chart.yaml)
+          APP_VERSION=$(yq eval '.appVersion' charts/system-upgrade-controller/Chart.yaml)
+          echo "version=${CHART_VERSION}" >> $GITHUB_OUTPUT
+          echo "name=${CHART_NAME}" >> $GITHUB_OUTPUT
+          echo "app_version=${APP_VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${CHART_NAME}-${CHART_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Check if version already exists
+        id: check-version
+        run: |
+          if gh release view "${{ steps.chart-version.outputs.tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release ${{ steps.chart-version.outputs.tag }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Release ${{ steps.chart-version.outputs.tag }} does not exist"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run validation tests
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          echo "Running validation for ${{ steps.chart-version.outputs.name }} v${{ steps.chart-version.outputs.version }}"
+
+          # Lint
+          helm lint charts/system-upgrade-controller
+
+          # Schema validation
+          check-jsonschema --schemafile charts/system-upgrade-controller/values.schema.json charts/system-upgrade-controller/values.yaml
+
+          # Unit tests
+          helm unittest charts/system-upgrade-controller --color
+
+      - name: Login to GitHub Container Registry
+        if: steps.check-version.outputs.exists == 'false'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Package and push chart
+        if: steps.check-version.outputs.exists == 'false'
+        id: push
+        run: |
+          # Package chart
+          helm package charts/system-upgrade-controller
+
+          # Push to GHCR
+          CHART_FILE="${{ steps.chart-version.outputs.name }}-${{ steps.chart-version.outputs.version }}.tgz"
+          helm push "${CHART_FILE}" oci://ghcr.io/${{ github.repository_owner }}/charts
+
+          # Get digest
+          DIGEST=$(helm show chart oci://ghcr.io/${{ github.repository_owner }}/charts/${{ steps.chart-version.outputs.name }} --version ${{ steps.chart-version.outputs.version }} 2>&1 | grep -oP 'sha256:[a-f0-9]{64}' | head -1)
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "Pushed chart with digest: ${DIGEST}"
+
+      - name: Sign chart with cosign
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          IMAGE_URI="ghcr.io/${{ github.repository_owner }}/charts/${{ steps.chart-version.outputs.name }}:${{ steps.chart-version.outputs.version }}"
+          echo "Signing ${IMAGE_URI}"
+          cosign sign --yes "${IMAGE_URI}"
+          echo "Chart signed successfully"
+
+      - name: Extract changelog
+        if: steps.check-version.outputs.exists == 'false'
+        id: changelog
+        run: |
+          CHANGELOG_RAW=$(yq eval '.annotations."artifacthub.io/changes"' charts/system-upgrade-controller/Chart.yaml)
+
+          RELEASE_BODY="## Chart: ${{ steps.chart-version.outputs.name }} v${{ steps.chart-version.outputs.version }}
+
+          **App Version**: ${{ steps.chart-version.outputs.app_version }}
+
+          ### Installation
+
+          \`\`\`bash
+          helm install system-upgrade-controller \\
+            oci://ghcr.io/${{ github.repository_owner }}/charts/system-upgrade-controller \\
+            --version ${{ steps.chart-version.outputs.version }}
+          \`\`\`
+
+          ### Verification
+
+          \`\`\`bash
+          cosign verify \\
+            ghcr.io/${{ github.repository_owner }}/charts/system-upgrade-controller:${{ steps.chart-version.outputs.version }} \\
+            --certificate-identity \"https://github.com/${{ github.repository }}/.github/workflows/publish-system-upgrade-controller.yaml@refs/heads/master\" \\
+            --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\"
+          \`\`\`
+          "
+
+          if [ "$CHANGELOG_RAW" != "null" ] && [ -n "$CHANGELOG_RAW" ]; then
+            RELEASE_BODY="${RELEASE_BODY}
+
+          ### Changelog
+
+          "
+            TEMP_FILE=$(mktemp)
+            SEPARATOR="|"
+            echo "$CHANGELOG_RAW" | yq eval ".[] | .kind + \"${SEPARATOR}\" + .description" - > "$TEMP_FILE"
+
+            while IFS="${SEPARATOR}" read -r kind description; do
+              case "$kind" in
+                "added")
+                  emoji="✨"
+                  ;;
+                "changed")
+                  emoji="🔄"
+                  ;;
+                "deprecated")
+                  emoji="⚠️"
+                  ;;
+                "removed")
+                  emoji="🗑️"
+                  ;;
+                "fixed")
+                  emoji="🐛"
+                  ;;
+                "security")
+                  emoji="🔒"
+                  ;;
+                *)
+                  emoji="📝"
+                  ;;
+              esac
+              RELEASE_BODY="${RELEASE_BODY}- ${emoji} ${description}
+          "
+            done < "$TEMP_FILE"
+
+            rm -f "$TEMP_FILE"
+          fi
+
+          RELEASE_BODY="${RELEASE_BODY}
+
+          ---
+
+          📦 **Published to**: \`ghcr.io/${{ github.repository_owner }}/charts/system-upgrade-controller:${{ steps.chart-version.outputs.version }}\`
+          🔐 **Signed with**: cosign (keyless)
+          📝 **Transparency log**: [Rekor](https://rekor.sigstore.dev/)
+          "
+
+          # Save to file for gh release create
+          echo "$RELEASE_BODY" > release-notes.md
+
+      - name: Create GitHub Release
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          gh release create "${{ steps.chart-version.outputs.tag }}" \
+            --title "${{ steps.chart-version.outputs.name }} v${{ steps.chart-version.outputs.version }}" \
+            --notes-file release-notes.md \
+            "${{ steps.chart-version.outputs.name }}-${{ steps.chart-version.outputs.version }}.tgz"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          echo "## 🚀 Release Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Chart**: ${{ steps.chart-version.outputs.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: ${{ steps.chart-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **App Version**: ${{ steps.chart-version.outputs.app_version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Registry**: \`ghcr.io/${{ github.repository_owner }}/charts/${{ steps.chart-version.outputs.name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Signed**: ✅ (cosign keyless)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Installation" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "helm install system-upgrade-controller \\" >> $GITHUB_STEP_SUMMARY
+          echo "  oci://ghcr.io/${{ github.repository_owner }}/charts/system-upgrade-controller \\" >> $GITHUB_STEP_SUMMARY
+          echo "  --version ${{ steps.chart-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+      - name: Version already exists
+        if: steps.check-version.outputs.exists == 'true'
+        run: |
+          echo "## ℹ️ Version Already Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Release **${{ steps.chart-version.outputs.tag }}** already exists." >> $GITHUB_STEP_SUMMARY
+          echo "No action taken." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.14'
+          python-version: '3.12'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,17 +10,37 @@ This is a Helm charts repository containing multiple Kubernetes application char
 - **cloudflare-tunnel**: Main chart for deploying Cloudflare tunnels
 - **frame**: Frame application deployment
 - **me-site**: Personal site deployment
+- **system-upgrade-controller**: Kubernetes-native node upgrade controller using declarative Plans
 - **transmission**: Transmission BitTorrent client deployment
 
 ## Development Commands
 
+### Required Tools Installation
+
+```bash
+# Helm plugin for unit testing
+helm plugin install https://github.com/helm-unittest/helm-unittest.git
+
+# Python tools for schema validation
+pip install check-jsonschema
+
+# Chart testing tool (ct) for linting and testing
+# Installation instructions: https://github.com/helm/chart-testing#installation
+# macOS:
+brew install chart-testing
+
+# helm-docs for README generation from templates
+# macOS:
+brew install norwoodj/tap/helm-docs
+# Linux: download from https://github.com/norwoodj/helm-docs/releases
+
+# Optional: yamllint for YAML validation
+pip install yamllint
+```
+
 ### Testing Commands
 
 ```bash
-# Install testing dependencies
-helm plugin install https://github.com/helm-unittest/helm-unittest.git
-pip install check-jsonschema
-
 # Test a specific chart (e.g., cloudflare-tunnel)
 helm lint charts/cloudflare-tunnel
 check-jsonschema --schemafile charts/cloudflare-tunnel/values.schema.json charts/cloudflare-tunnel/values.yaml
@@ -98,11 +118,39 @@ act workflow_dispatch --workflows .github/workflows/test.yaml --list
 When modifying charts, you MUST:
 
 1. **Bump chart version** in `Chart.yaml` following semver
+   - Breaking changes: bump major version (1.0.0 → 2.0.0)
+   - New features: bump minor version (1.0.0 → 1.1.0)
+   - Bug fixes: bump patch version (1.0.0 → 1.0.1)
+
 2. **Update `artifacthub.io/changes` annotations** in `Chart.yaml` with changelog entries
+   ```yaml
+   annotations:
+     artifacthub.io/changes: |-
+       - kind: added|changed|deprecated|removed|fixed|security
+         description: Brief description of the change
+   ```
+   Valid kinds:
+   - `added`: New features or functionality
+   - `changed`: Changes in existing functionality
+   - `deprecated`: Features marked for removal
+   - `removed`: Removed features
+   - `fixed`: Bug fixes
+   - `security`: Security fixes or improvements
+
 3. **Update `values.schema.json`** if adding new values
+
 4. **Add/update unit tests** in `tests/` directory using helm-unittest
-5. **Update chart README.md** (regenerate with helm-docs if `.gotmpl` template exists)
+
+5. **Regenerate README.md** if chart has `README.md.gotmpl` template:
+   ```bash
+   helm-docs charts/<chart-name>
+   # OR using Docker:
+   docker run --rm --volume "$(pwd):/helm-docs" jnorwood/helm-docs:v1.14.2 --chart-search-root=/helm-docs/charts/<chart-name>
+   ```
+   **CRITICAL**: CI will fail if README.md is not up-to-date with the template
+
 6. **Test changes locally** before submitting PR using commands above
+
 7. **Run lint and validation** for all changed charts
 
 ## Testing Architecture
@@ -129,12 +177,42 @@ cloudflare:
       service: http://test-service:80
 ```
 
+## Template Helpers Architecture
+
+All charts follow a standard pattern using `_helpers.tpl` for reusable template definitions:
+
+### Standard Helper Templates
+
+Every chart includes these standard helpers in `templates/_helpers.tpl`:
+
+- **`<chart-name>.name`**: Expands chart name, respects `nameOverride`
+- **`<chart-name>.fullname`**: Creates fully qualified app name (max 63 chars), respects `fullnameOverride`
+- **`<chart-name>.chart`**: Returns chart name and version for labels
+- **`<chart-name>.labels`**: Common labels including chart, version, managed-by
+- **`<chart-name>.selectorLabels`**: Selector labels for matching pods (name + instance)
+
+### Using Helpers in Templates
+
+```yaml
+metadata:
+  name: {{ include "cloudflare-tunnel.fullname" . }}
+  labels:
+    {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cloudflare-tunnel.selectorLabels" . | nindent 6 }}
+```
+
+**Important**: Always use `include` with `nindent` for proper indentation, not `template` or `indent`.
+
 ## CI/CD Architecture
 
 ### GitHub Actions Workflows
 
 - **test.yaml**: Runs lint, tests, and validation on chart changes
-- **publish.yaml**: Publishes charts to repository on master branch
+- **publish.yaml**: Publishes charts to GitHub Pages (chart-releaser for legacy charts)
+- **publish-system-upgrade-controller.yaml**: Modern OCI + cosign workflow for system-upgrade-controller
 - **renovate-update.yaml**: Handles dependency updates
 
 ### Change Detection
@@ -149,6 +227,57 @@ To manually trigger tests for specific charts:
 # Using GitHub CLI
 gh workflow run test.yaml --field charts='["charts/cloudflare-tunnel"]'
 ```
+
+## Publishing Charts
+
+### Modern OCI Publishing (system-upgrade-controller)
+
+The `system-upgrade-controller` chart uses a modern publishing pipeline with:
+
+**Publishing to GHCR (GitHub Container Registry)**:
+- OCI-native Helm chart storage
+- Automatic authentication via `docker/login-action` with GITHUB_TOKEN
+- No manual credentials needed
+
+**Keyless Signing with cosign**:
+- Signatures stored in Rekor transparency log
+- GitHub OIDC for ephemeral credentials
+- No key management required
+
+**Installation**:
+```bash
+# Install from GHCR
+helm install system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
+  --version 0.1.0
+```
+
+**Verification**:
+```bash
+# Verify signature
+cosign verify \
+  ghcr.io/lexfrei/charts/system-upgrade-controller:0.1.0 \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-system-upgrade-controller.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+**Workflow Features**:
+- Validates chart with lint + unittest + schema before publishing
+- Checks if version already exists (idempotent)
+- Creates GitHub Release with formatted changelog
+- Provides installation and verification instructions
+
+**Triggering Publication**:
+```bash
+# Manual trigger
+gh workflow run publish-system-upgrade-controller.yaml
+
+# Automatic: Push changes to charts/system-upgrade-controller/** on master branch
+```
+
+### Legacy Publishing (other charts)
+
+Other charts still use `chart-releaser` action publishing to GitHub Pages at `https://charts.lex.la`.
 
 ## Project Structure
 
@@ -196,6 +325,66 @@ Publishing process:
 2. Chart packages are built
 3. Index is updated
 4. Charts are pushed to repository
+
+## Quick Reference
+
+### Complete Chart Development Workflow
+
+```bash
+# 1. Make changes to chart
+vim charts/cloudflare-tunnel/values.yaml
+
+# 2. Bump version in Chart.yaml
+vim charts/cloudflare-tunnel/Chart.yaml
+
+# 3. Update schema if needed
+vim charts/cloudflare-tunnel/values.schema.json
+
+# 4. Regenerate README if .gotmpl exists
+helm-docs charts/cloudflare-tunnel
+
+# 5. Run full test suite
+helm lint charts/cloudflare-tunnel
+check-jsonschema --schemafile charts/cloudflare-tunnel/values.schema.json charts/cloudflare-tunnel/values.yaml
+helm unittest charts/cloudflare-tunnel --color
+
+# 6. Dry-run template generation
+helm template test-release charts/cloudflare-tunnel -f test-values.yaml
+```
+
+### test-workflow.sh Script
+
+Local script for testing workflow logic and JSON validation before pushing:
+
+```bash
+./test-workflow.sh
+```
+
+This script validates:
+- JSON parsing logic used in CI
+- YAML syntax in workflow files (requires `yq`)
+- Basic workflow structure
+
+Use this to catch workflow issues before committing.
+
+### Common One-Liners
+
+```bash
+# List all charts with tests
+find charts -name "tests" -type d
+
+# Validate all schemas at once
+for chart in charts/*/; do [ -f "$chart/values.schema.json" ] && check-jsonschema --schemafile "$chart/values.schema.json" "$chart/values.yaml"; done
+
+# Lint all charts
+for chart in charts/*/; do helm lint "$chart"; done
+
+# Run all tests for all charts
+for chart in charts/*/; do [ -d "$chart/tests" ] && helm unittest "$chart" --color; done
+
+# Trigger test workflow for specific chart
+gh workflow run test.yaml --field charts='["charts/cloudflare-tunnel"]'
+```
 
 ## Helm-Specific Best Practices
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ Helm chart for deploying Cloudflare Tunnel (cloudflared) in Kubernetes. This cha
 
 [📖 Documentation](./charts/cloudflare-tunnel/README.md) | [🔧 Values](./charts/cloudflare-tunnel/values.yaml)
 
+### [system-upgrade-controller](./charts/system-upgrade-controller)
+
+Kubernetes-native upgrade controller for automated node upgrades using declarative Plans. Based on [Rancher System Upgrade Controller](https://github.com/rancher/system-upgrade-controller).
+
+**Key Features:**
+
+- Declarative node upgrade plans using CRDs
+- Automated rolling upgrades with configurable concurrency
+- Node drain and cordon support
+- Suitable for k3s, RKE2, and other Kubernetes distributions
+- Highly configurable job parameters
+- **Published to GHCR as OCI artifact** with cosign signatures
+
+**Installation (OCI)**:
+```bash
+helm install system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
+  --version 0.1.0
+```
+
+[📖 Documentation](./charts/system-upgrade-controller/README.md) | [🔧 Values](./charts/system-upgrade-controller/values.yaml)
+
 ## Installation
 
 ### Add Helm Repository

--- a/charts/system-upgrade-controller/.helmignore
+++ b/charts/system-upgrade-controller/.helmignore
@@ -1,0 +1,30 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# CI files
+.github/
+.gitlab-ci.yml
+.travis.yml
+# Test files
+tests/
+*.test.yaml

--- a/charts/system-upgrade-controller/Chart.yaml
+++ b/charts/system-upgrade-controller/Chart.yaml
@@ -1,0 +1,45 @@
+annotations:
+  artifacthub.io/category: infrastructure
+  artifacthub.io/changes: |-
+    - kind: added
+      description: Initial release of system-upgrade-controller Helm chart
+  artifacthub.io/license: BSD-3-Clause
+  artifacthub.io/links: |
+    - name: Chart Repository
+      url: https://github.com/lexfrei/charts/
+    - name: System Upgrade Controller
+      url: https://github.com/rancher/system-upgrade-controller/
+
+apiVersion: v2
+name: system-upgrade-controller
+description: Kubernetes-native upgrade controller for nodes using declarative Plans
+type: application
+
+version: "0.1.0"
+# renovate: datasource=github-releases depName=rancher/system-upgrade-controller
+appVersion: "v0.17.0"
+
+icon: https://avatars.githubusercontent.com/u/9343010
+
+home: https://github.com/lexfrei/charts/
+
+keywords:
+  - system-upgrade
+  - upgrade
+  - controller
+  - node-upgrade
+  - k3s
+  - rancher
+  - helm-chart
+  - kubernetes
+  - infrastructure
+  - automation
+
+maintainers:
+  - name: lexfrei
+    email: f@lex.la
+    url: https://github.com/lexfrei
+
+sources:
+  - https://github.com/lexfrei/charts/
+  - https://github.com/rancher/system-upgrade-controller/

--- a/charts/system-upgrade-controller/README.md
+++ b/charts/system-upgrade-controller/README.md
@@ -1,0 +1,215 @@
+# system-upgrade-controller
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.0](https://img.shields.io/badge/AppVersion-v0.17.0-informational?style=flat-square)
+
+Kubernetes-native upgrade controller for nodes using declarative Plans
+
+**Homepage:** <https://github.com/lexfrei/charts/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| lexfrei | <f@lex.la> | <https://github.com/lexfrei> |
+
+## Source Code
+
+* <https://github.com/lexfrei/charts/>
+* <https://github.com/rancher/system-upgrade-controller/>
+
+## Introduction
+
+This chart deploys the [Rancher System Upgrade Controller](https://github.com/rancher/system-upgrade-controller) on a Kubernetes cluster using the Helm package manager. The System Upgrade Controller is a Kubernetes-native upgrade controller that enables automated upgrades of cluster nodes through declarative Plans.
+
+## Features
+
+- Declarative node upgrade plans using Custom Resource Definitions (CRDs)
+- Automated rolling upgrades with configurable concurrency
+- Node drain and cordon support
+- Suitable for k3s, RKE2, and other Kubernetes distributions
+- Highly configurable job parameters
+- Full RBAC support
+
+## Installing the Chart
+
+### From OCI Registry (GHCR)
+
+This chart is published to GitHub Container Registry as an OCI artifact.
+
+```bash
+# Install latest version
+helm install system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller
+
+# Install specific version
+helm install system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
+  --version 0.1.0
+
+# Install with custom values
+helm install system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
+  --version 0.1.0 \
+  --values custom-values.yaml
+```
+
+### Chart Verification
+
+This chart is signed with [cosign](https://github.com/sigstore/cosign) using keyless signing. Verify the signature before installation:
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/system-upgrade-controller:0.1.0 \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-system-upgrade-controller.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+The signature is stored in the [Rekor transparency log](https://rekor.sigstore.dev/) for public verification.
+
+## Uninstalling the Chart
+
+```bash
+helm delete system-upgrade-controller
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"Exists"},{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]}]}},"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchExpressions":[{"key":"app.kubernetes.io/name","operator":"In","values":["system-upgrade-controller"]}]},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for the controller deployment |
+| controller | object | `{"debug":false,"leaderElect":true,"name":"system-upgrade-controller","threads":2}` | Controller configuration |
+| controller.debug | bool | `false` | Enable debug logging |
+| controller.leaderElect | bool | `true` | Enable leader election |
+| controller.name | string | `"system-upgrade-controller"` | Controller name (from metadata labels) |
+| controller.threads | int | `2` | Number of threads for the controller |
+| crd | object | `{"install":true}` | CRD installation |
+| crd.install | bool | `true` | Install the CRD (Plans) |
+| fullnameOverride | string | `""` |  |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"rancher/system-upgrade-controller","tag":""}` | Image configuration |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| imagePullSecrets | list | `[]` |  |
+| job | object | `{"activeDeadlineSeconds":900,"backoffLimit":99,"imagePullPolicy":"Always","kubectlImage":"rancher/kubectl:v1.30.3","privileged":true,"ttlSecondsAfterFinish":900}` | Job configuration for upgrade plans |
+| job.activeDeadlineSeconds | int | `900` | Active deadline seconds for jobs |
+| job.backoffLimit | int | `99` | Backoff limit for job failures |
+| job.imagePullPolicy | string | `"Always"` | Image pull policy for upgrade jobs |
+| job.kubectlImage | string | `"rancher/kubectl:v1.30.3"` | kubectl image for upgrade jobs |
+| job.privileged | bool | `true` | Run upgrade jobs as privileged |
+| job.ttlSecondsAfterFinish | int | `900` | TTL seconds after job finish |
+| nameOverride | string | `""` |  |
+| namespace | object | `{"create":true,"name":"system-upgrade"}` | Namespace where the controller will be deployed |
+| namespace.create | bool | `true` | Create the namespace |
+| namespace.name | string | `"system-upgrade"` | Name of the namespace |
+| nodeSelector | object | `{}` | Node selector for the controller deployment |
+| plan | object | `{"pollingInterval":"15m"}` | Plan polling configuration |
+| plan.pollingInterval | string | `"15m"` | Polling interval for checking plan updates |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Security context for the pod |
+| resources | object | `{}` | Resource limits and requests |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the container |
+| serviceAccount | object | `{"annotations":{},"create":true,"name":"system-upgrade"}` | Service account configuration |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `"system-upgrade"` | The name of the service account to use |
+| tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/controlplane","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"},{"effect":"NoExecute","key":"node-role.kubernetes.io/etcd","operator":"Exists"}]` | Tolerations for the controller deployment |
+
+## Example Configurations
+
+### Basic k3s Upgrade Plan
+
+After installing the controller, create a Plan to upgrade k3s:
+
+```yaml
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: k3s-server
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  cordon: true
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+  serviceAccountName: system-upgrade
+  upgrade:
+    image: rancher/k3s-upgrade
+  version: v1.28.5+k3s1
+```
+
+### Custom Namespace
+
+```yaml
+namespace:
+  name: my-upgrade-namespace
+  create: true
+```
+
+### Increased Job Timeout
+
+```yaml
+job:
+  activeDeadlineSeconds: 1800  # 30 minutes
+  ttlSecondsAfterFinish: 1800
+```
+
+### Debug Mode
+
+```yaml
+controller:
+  debug: true
+```
+
+### Disable CRD Installation
+
+If CRDs are managed separately:
+
+```yaml
+crd:
+  install: false
+```
+
+## Configuration and Installation Details
+
+### RBAC
+
+The chart creates the following RBAC resources:
+- ClusterRole for controller operations
+- ClusterRole for node draining operations
+- Role for namespace-scoped job management
+- Corresponding bindings for the service account
+
+### Security
+
+The controller runs with a restricted security context:
+- Non-root user (UID 65534)
+- No privilege escalation
+- All capabilities dropped
+- RuntimeDefault seccomp profile
+
+### Affinity and Tolerations
+
+By default, the controller is configured to run on control-plane nodes with appropriate tolerations and pod anti-affinity rules.
+
+## Upgrading the Chart
+
+```bash
+# Upgrade to latest version
+helm upgrade system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller
+
+# Upgrade to specific version
+helm upgrade system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
+  --version 0.2.0
+```
+
+## Resources
+
+- [System Upgrade Controller Documentation](https://github.com/rancher/system-upgrade-controller)
+- [k3s Automated Upgrades](https://docs.k3s.io/upgrades/automated)
+- [Plan CRD Reference](https://github.com/rancher/system-upgrade-controller/blob/master/pkg/apis/upgrade.cattle.io/v1/types.go)
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/system-upgrade-controller/README.md.gotmpl
+++ b/charts/system-upgrade-controller/README.md.gotmpl
@@ -1,0 +1,172 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Introduction
+
+This chart deploys the [Rancher System Upgrade Controller](https://github.com/rancher/system-upgrade-controller) on a Kubernetes cluster using the Helm package manager. The System Upgrade Controller is a Kubernetes-native upgrade controller that enables automated upgrades of cluster nodes through declarative Plans.
+
+## Features
+
+- Declarative node upgrade plans using Custom Resource Definitions (CRDs)
+- Automated rolling upgrades with configurable concurrency
+- Node drain and cordon support
+- Suitable for k3s, RKE2, and other Kubernetes distributions
+- Highly configurable job parameters
+- Full RBAC support
+
+## Installing the Chart
+
+### From OCI Registry (GHCR)
+
+This chart is published to GitHub Container Registry as an OCI artifact.
+
+```bash
+# Install latest version
+helm install system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller
+
+# Install specific version
+helm install system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
+  --version 0.1.0
+
+# Install with custom values
+helm install system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
+  --version 0.1.0 \
+  --values custom-values.yaml
+```
+
+### Chart Verification
+
+This chart is signed with [cosign](https://github.com/sigstore/cosign) using keyless signing. Verify the signature before installation:
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/system-upgrade-controller:0.1.0 \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-system-upgrade-controller.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+The signature is stored in the [Rekor transparency log](https://rekor.sigstore.dev/) for public verification.
+
+## Uninstalling the Chart
+
+```bash
+helm delete system-upgrade-controller
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Example Configurations
+
+### Basic k3s Upgrade Plan
+
+After installing the controller, create a Plan to upgrade k3s:
+
+```yaml
+apiVersion: upgrade.cattle.io/v1
+kind: Plan
+metadata:
+  name: k3s-server
+  namespace: system-upgrade
+spec:
+  concurrency: 1
+  cordon: true
+  nodeSelector:
+    matchExpressions:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+  serviceAccountName: system-upgrade
+  upgrade:
+    image: rancher/k3s-upgrade
+  version: v1.28.5+k3s1
+```
+
+### Custom Namespace
+
+```yaml
+namespace:
+  name: my-upgrade-namespace
+  create: true
+```
+
+### Increased Job Timeout
+
+```yaml
+job:
+  activeDeadlineSeconds: 1800  # 30 minutes
+  ttlSecondsAfterFinish: 1800
+```
+
+### Debug Mode
+
+```yaml
+controller:
+  debug: true
+```
+
+### Disable CRD Installation
+
+If CRDs are managed separately:
+
+```yaml
+crd:
+  install: false
+```
+
+## Configuration and Installation Details
+
+### RBAC
+
+The chart creates the following RBAC resources:
+- ClusterRole for controller operations
+- ClusterRole for node draining operations
+- Role for namespace-scoped job management
+- Corresponding bindings for the service account
+
+### Security
+
+The controller runs with a restricted security context:
+- Non-root user (UID 65534)
+- No privilege escalation
+- All capabilities dropped
+- RuntimeDefault seccomp profile
+
+### Affinity and Tolerations
+
+By default, the controller is configured to run on control-plane nodes with appropriate tolerations and pod anti-affinity rules.
+
+## Upgrading the Chart
+
+```bash
+# Upgrade to latest version
+helm upgrade system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller
+
+# Upgrade to specific version
+helm upgrade system-upgrade-controller \
+  oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
+  --version 0.2.0
+```
+
+## Resources
+
+- [System Upgrade Controller Documentation](https://github.com/rancher/system-upgrade-controller)
+- [k3s Automated Upgrades](https://docs.k3s.io/upgrades/automated)
+- [Plan CRD Reference](https://github.com/rancher/system-upgrade-controller/blob/master/pkg/apis/upgrade.cattle.io/v1/types.go)
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/system-upgrade-controller/templates/_helpers.tpl
+++ b/charts/system-upgrade-controller/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "system-upgrade-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "system-upgrade-controller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "system-upgrade-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "system-upgrade-controller.labels" -}}
+helm.sh/chart: {{ include "system-upgrade-controller.chart" . }}
+{{ include "system-upgrade-controller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "system-upgrade-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "system-upgrade-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "system-upgrade-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default "system-upgrade" .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the namespace to use
+*/}}
+{{- define "system-upgrade-controller.namespace" -}}
+{{- .Values.namespace.name }}
+{{- end }}

--- a/charts/system-upgrade-controller/templates/clusterrole-drainer.yaml
+++ b/charts/system-upgrade-controller/templates/clusterrole-drainer.yaml
@@ -1,0 +1,41 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller-drainer
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+rules:
+  # Needed to evict pods
+  - apiGroups:
+      - ""
+    resources:
+      - "pods/eviction"
+    verbs:
+      - "create"
+  # Needed to list/delete pods by Node
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+      - "list"
+      - "delete"
+  # Needed to cordon Nodes
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - "get"
+      - "patch"
+  # Needed to determine Pod owners
+  - apiGroups:
+      - "apps"
+    resources:
+      - "statefulsets"
+      - "daemonsets"
+      - "replicasets"
+    verbs:
+      - "get"
+      - "list"

--- a/charts/system-upgrade-controller/templates/clusterrole.yaml
+++ b/charts/system-upgrade-controller/templates/clusterrole.yaml
@@ -1,0 +1,78 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system-upgrade-controller
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - create
+  - patch
+  - update
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  resourceNames:
+  - "system-upgrade-controller"
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - upgrade.cattle.io
+  resources:
+  - plans
+  - plans/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete

--- a/charts/system-upgrade-controller/templates/clusterrolebinding.yaml
+++ b/charts/system-upgrade-controller/templates/clusterrolebinding.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ include "system-upgrade-controller.serviceAccountName" . }}
+  namespace: {{ include "system-upgrade-controller.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system-upgrade-drainer
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system-upgrade-controller-drainer
+subjects:
+- kind: ServiceAccount
+  name: {{ include "system-upgrade-controller.serviceAccountName" . }}
+  namespace: {{ include "system-upgrade-controller.namespace" . }}

--- a/charts/system-upgrade-controller/templates/configmap.yaml
+++ b/charts/system-upgrade-controller/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-controller-env
+  namespace: {{ include "system-upgrade-controller.namespace" . }}
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+data:
+  SYSTEM_UPGRADE_CONTROLLER_DEBUG: {{ .Values.controller.debug | quote }}
+  SYSTEM_UPGRADE_CONTROLLER_THREADS: {{ .Values.controller.threads | quote }}
+  SYSTEM_UPGRADE_CONTROLLER_LEADER_ELECT: {{ .Values.controller.leaderElect | quote }}
+  SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS: {{ .Values.job.activeDeadlineSeconds | quote }}
+  SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT: {{ .Values.job.backoffLimit | quote }}
+  SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY: {{ .Values.job.imagePullPolicy | quote }}
+  SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE: {{ .Values.job.kubectlImage | quote }}
+  SYSTEM_UPGRADE_JOB_PRIVILEGED: {{ .Values.job.privileged | quote }}
+  SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH: {{ .Values.job.ttlSecondsAfterFinish | quote }}
+  SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL: {{ .Values.plan.pollingInterval | quote }}

--- a/charts/system-upgrade-controller/templates/crd.yaml
+++ b/charts/system-upgrade-controller/templates/crd.yaml
@@ -1,0 +1,1301 @@
+{{- if .Values.crd.install }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.3
+  name: plans.upgrade.cattle.io
+spec:
+  group: upgrade.cattle.io
+  names:
+    kind: Plan
+    listKind: PlanList
+    plural: plans
+    singular: plan
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.upgrade.image
+      name: Image
+      type: string
+    - jsonPath: .spec.channel
+      name: Channel
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Complete')].status
+      name: Complete
+      type: string
+    - jsonPath: .status.conditions[?(@.message!='')].message
+      name: Message
+      type: string
+    - jsonPath: .status.applying
+      name: Applying
+      priority: 10
+      type: string
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: Plan represents a set of Jobs to apply an upgrade (or other operation)
+          to set of Nodes.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlanSpec represents the user-configurable details of a Plan.
+            properties:
+              channel:
+                description: A URL that returns HTTP 302 with the last path element
+                  of the value returned in the Location header assumed to be an image
+                  tag (after munging "+" to "-").
+                type: string
+              concurrency:
+                description: The maximum number of concurrent nodes to apply this
+                  update on.
+                format: int64
+                type: integer
+              cordon:
+                description: |-
+                  If Cordon is true, the node is cordoned before the upgrade container is run.
+                  If drain is specified, the value for cordon is ignored, and the node is cordoned.
+                  If neither drain nor cordon are specified and the node is marked as schedulable=false it will not be marked as schedulable=true when the Job completes.
+                type: boolean
+              drain:
+                description: Configuration for draining nodes prior to upgrade. If
+                  left unspecified, no drain will be performed.
+                properties:
+                  deleteEmptydirData:
+                    type: boolean
+                  deleteLocalData:
+                    type: boolean
+                  disableEviction:
+                    type: boolean
+                  force:
+                    type: boolean
+                  gracePeriod:
+                    format: int32
+                    type: integer
+                  ignoreDaemonSets:
+                    type: boolean
+                  podSelector:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  skipWaitForDeleteTimeout:
+                    type: integer
+                  timeout:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      If a string, this is passed through directly to the `kubectl drain` command.
+                      If an int, this represents the duration as a count of nanoseconds, and will be converted to a duration string when passed to the `kubectl drain` command.
+                    x-kubernetes-int-or-string: true
+                type: object
+              exclusive:
+                description: Jobs for exclusive plans cannot be run alongside any
+                  other exclusive plan.
+                type: boolean
+              imagePullSecrets:
+                description: Image Pull Secrets, used to pull images for the Job.
+                items:
+                  description: |-
+                    LocalObjectReference contains enough information to let you locate the
+                    referenced object inside the same namespace.
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                type: array
+              jobActiveDeadlineSecs:
+                description: |-
+                  Sets ActiveDeadlineSeconds on Jobs generated to apply this Plan.
+                  If the Job does not complete within this time, the Plan will stop processing until it is updated to trigger a redeploy.
+                  If set to 0, Jobs have no deadline. If not set, the controller default value is used.
+                format: int64
+                type: integer
+              nodeSelector:
+                description: Select which nodes this plan can be applied to.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              postCompleteDelay:
+                description: Time after a Job for one Node is complete before a new
+                  Job will be created for the next Node.
+                type: string
+              prepare:
+                description: The prepare init container, if specified, is run before
+                  cordon/drain which is run before the upgrade container.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  envs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image name. If the tag is omitted, the value from
+                      .status.latestVersion will be used.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext holds security configuration that will be applied to a container.
+                      Some fields are present in both SecurityContext and PodSecurityContext.  When both
+                      are set, the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default value is Default which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  volumes:
+                    items:
+                      description: HostPath volume to mount into the pod
+                      properties:
+                        destination:
+                          description: Path to mount the Volume at within the Pod.
+                          type: string
+                        name:
+                          description: Name of the Volume as it will appear within
+                            the Pod spec.
+                          type: string
+                        source:
+                          description: Path on the host to mount.
+                          type: string
+                      required:
+                      - destination
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              priorityClassName:
+                description: Priority Class Name of Job, if specified.
+                type: string
+              secrets:
+                description: Secrets to be mounted into the Job Pod.
+                items:
+                  description: SecretSpec describes a Secret to be mounted for prepare/upgrade
+                    containers.
+                  properties:
+                    defaultMode:
+                      description: Mode to mount the Secret volume with.
+                      format: int32
+                      type: integer
+                    ignoreUpdates:
+                      description: If set to true, the Secret contents will not be
+                        hashed, and changes to the Secret will not trigger new application
+                        of the Plan.
+                      type: boolean
+                    name:
+                      description: Secret name
+                      type: string
+                    path:
+                      description: Path to mount the Secret volume within the Pod.
+                      type: string
+                  required:
+                  - name
+                  - path
+                  type: object
+                type: array
+              serviceAccountName:
+                description: The service account for the pod to use. As with normal
+                  pods, if not specified the default service account from the namespace
+                  will be assigned.
+                type: string
+              tolerations:
+                description: |-
+                  Specify which node taints should be tolerated by pods applying the upgrade.
+                  Anything specified here is appended to the default of:
+                  - `{key: node.kubernetes.io/unschedulable, effect: NoSchedule, operator: Exists}`
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+              upgrade:
+                description: The upgrade container; must be specified.
+                properties:
+                  args:
+                    items:
+                      type: string
+                    type: array
+                  command:
+                    items:
+                      type: string
+                    type: array
+                  envFrom:
+                    items:
+                      description: EnvFromSource represents the source of a set of
+                        ConfigMaps or Secrets
+                      properties:
+                        configMapRef:
+                          description: The ConfigMap to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          description: |-
+                            Optional text to prepend to the name of each environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        secretRef:
+                          description: The Secret to select from
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: Specify whether the Secret must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
+                  envs:
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the environment variable.
+                            May consist of any printable ASCII characters except '='.
+                          type: string
+                        value:
+                          description: |-
+                            Variable references $(VAR_NAME) are expanded
+                            using the previously defined environment variables in the container and
+                            any service environment variables. If a variable cannot be resolved,
+                            the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                            Escaped references will never be expanded, regardless of whether the variable
+                            exists or not.
+                            Defaults to "".
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              description: |-
+                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath
+                                    is written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the
+                                    specified API version.
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              description: |-
+                                FileKeyRef selects a key of the env file.
+                                Requires the EnvFiles feature gate to be enabled.
+                              properties:
+                                key:
+                                  description: |-
+                                    The key within the env file. An invalid key will prevent the pod from starting.
+                                    The keys defined within a source may consist of any printable ASCII characters except '='.
+                                    During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                  type: string
+                                optional:
+                                  default: false
+                                  description: |-
+                                    Specify whether the file or its key must be defined. If the file or key
+                                    does not exist, then the env var is not published.
+                                    If optional is set to true and the specified key does not exist,
+                                    the environment variable will not be set in the Pod's containers.
+
+                                    If optional is set to false and the specified key does not exist,
+                                    an error will be returned during Pod creation.
+                                  type: boolean
+                                path:
+                                  description: |-
+                                    The path within the volume from which to select the file.
+                                    Must be relative and may not contain the '..' path or start with '..'.
+                                  type: string
+                                volumeName:
+                                  description: The name of the volume mount containing
+                                    the env file.
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              description: |-
+                                Selects a resource of the container: only resources limits and requests
+                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: Specifies the output format of the
+                                    exposed resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's
+                                namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  image:
+                    description: Image name. If the tag is omitted, the value from
+                      .status.latestVersion will be used.
+                    type: string
+                  securityContext:
+                    description: |-
+                      SecurityContext holds security configuration that will be applied to a container.
+                      Some fields are present in both SecurityContext and PodSecurityContext.  When both
+                      are set, the values in SecurityContext take precedence.
+                    properties:
+                      allowPrivilegeEscalation:
+                        description: |-
+                          AllowPrivilegeEscalation controls whether a process can gain more
+                          privileges than its parent process. This bool directly controls if
+                          the no_new_privs flag will be set on the container process.
+                          AllowPrivilegeEscalation is true always when the container is:
+                          1) run as Privileged
+                          2) has CAP_SYS_ADMIN
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      appArmorProfile:
+                        description: |-
+                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                          overrides the pod's appArmorProfile.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile loaded on the node that should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must match the loaded name of the profile.
+                              Must be set if and only if type is "Localhost".
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of AppArmor profile will be applied.
+                              Valid options are:
+                                Localhost - a profile pre-loaded on the node.
+                                RuntimeDefault - the container runtime's default profile.
+                                Unconfined - no AppArmor enforcement.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      capabilities:
+                        description: |-
+                          The capabilities to add/drop when running containers.
+                          Defaults to the default set of capabilities granted by the container runtime.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          add:
+                            description: Added capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          drop:
+                            description: Removed capabilities
+                            items:
+                              description: Capability represent POSIX capabilities
+                                type
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      privileged:
+                        description: |-
+                          Run container in privileged mode.
+                          Processes in privileged containers are essentially equivalent to root on the host.
+                          Defaults to false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      procMount:
+                        description: |-
+                          procMount denotes the type of proc mount to use for the containers.
+                          The default value is Default which uses the container runtime defaults for
+                          readonly paths and masked paths.
+                          This requires the ProcMountType feature flag to be enabled.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: string
+                      readOnlyRootFilesystem:
+                        description: |-
+                          Whether this container has a read-only root filesystem.
+                          Default is false.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        type: boolean
+                      runAsGroup:
+                        description: |-
+                          The GID to run the entrypoint of the container process.
+                          Uses runtime default if unset.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: |-
+                          Indicates that the container must run as a non-root user.
+                          If true, the Kubelet will validate the image at runtime to ensure that it
+                          does not run as UID 0 (root) and fail to start the container if it does.
+                          If unset or false, no such validation will be performed.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: |-
+                          The UID to run the entrypoint of the container process.
+                          Defaults to user specified in image metadata if unspecified.
+                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: |-
+                          The SELinux context to be applied to the container.
+                          If unspecified, the container runtime will allocate a random SELinux context for each
+                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies
+                              to the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies
+                              to the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies
+                              to the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies
+                              to the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: |-
+                          The seccomp options to use by this container. If seccomp options are
+                          provided at both the pod & container level, the container options
+                          override the pod options.
+                          Note that this field cannot be set when spec.os.name is windows.
+                        properties:
+                          localhostProfile:
+                            description: |-
+                              localhostProfile indicates a profile defined in a file on the node should be used.
+                              The profile must be preconfigured on the node to work.
+                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                            type: string
+                          type:
+                            description: |-
+                              type indicates which kind of seccomp profile will be applied.
+                              Valid options are:
+
+                              Localhost - a profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied.
+                            type: string
+                        required:
+                        - type
+                        type: object
+                      windowsOptions:
+                        description: |-
+                          The Windows specific settings applied to all containers.
+                          If unspecified, the options from the PodSecurityContext will be used.
+                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          Note that this field cannot be set when spec.os.name is linux.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: |-
+                              GMSACredentialSpec is where the GMSA admission webhook
+                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                              GMSA credential spec named by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the
+                              GMSA credential spec to use.
+                            type: string
+                          hostProcess:
+                            description: |-
+                              HostProcess determines if a container should be run as a 'Host Process' container.
+                              All of a Pod's containers must have the same effective HostProcess value
+                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                            type: boolean
+                          runAsUserName:
+                            description: |-
+                              The UserName in Windows to run the entrypoint of the container process.
+                              Defaults to the user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  volumes:
+                    items:
+                      description: HostPath volume to mount into the pod
+                      properties:
+                        destination:
+                          description: Path to mount the Volume at within the Pod.
+                          type: string
+                        name:
+                          description: Name of the Volume as it will appear within
+                            the Pod spec.
+                          type: string
+                        source:
+                          description: Path on the host to mount.
+                          type: string
+                      required:
+                      - destination
+                      - name
+                      - source
+                      type: object
+                    type: array
+                required:
+                - image
+                type: object
+              version:
+                description: Providing a value for version will prevent polling/resolution
+                  of the channel if specified.
+                type: string
+              window:
+                description: |-
+                  A time window in which to execute Jobs for this Plan.
+                  Jobs will not be generated outside this time window, but may continue executing into the window once started.
+                properties:
+                  days:
+                    description: Days that this time window is valid for
+                    items:
+                      enum:
+                      - "0"
+                      - su
+                      - sun
+                      - sunday
+                      - "1"
+                      - mo
+                      - mon
+                      - monday
+                      - "2"
+                      - tu
+                      - tue
+                      - tuesday
+                      - "3"
+                      - we
+                      - wed
+                      - wednesday
+                      - "4"
+                      - th
+                      - thu
+                      - thursday
+                      - "5"
+                      - fr
+                      - fri
+                      - friday
+                      - "6"
+                      - sa
+                      - sat
+                      - saturday
+                      type: string
+                    minItems: 1
+                    type: array
+                  endTime:
+                    description: End of the time window.
+                    type: string
+                  startTime:
+                    description: Start of the time window.
+                    type: string
+                  timeZone:
+                    description: Time zone for the time window; if not specified UTC
+                      will be used.
+                    type: string
+                type: object
+            required:
+            - upgrade
+            type: object
+          status:
+            description: PlanStatus represents the resulting state from processing
+              Plan events.
+            properties:
+              applying:
+                description: List of Node names that the Plan is currently being applied
+                  on.
+                items:
+                  type: string
+                type: array
+              conditions:
+                description: |-
+                  `LatestResolved` indicates that the latest version as per the spec has been determined.
+                  `Validated` indicates that the plan spec has been validated.
+                  `Complete` indicates that the latest version of the plan has completed on all selected nodes. If any Jobs for the Plan fail to complete, this condition will remain false, and the reason and message will reflect the source of the error.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of cluster condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              latestHash:
+                description: The hash of the most recently applied plan .spec.
+                type: string
+              latestVersion:
+                description: The latest version, as resolved from .spec.version, or
+                  the channel server.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+{{- end }}

--- a/charts/system-upgrade-controller/templates/deployment.yaml
+++ b/charts/system-upgrade-controller/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-upgrade-controller
+  namespace: {{ include "system-upgrade-controller.namespace" . }}
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      upgrade.cattle.io/controller: system-upgrade-controller
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/component: controller
+        app.kubernetes.io/name: system-upgrade-controller
+        upgrade.cattle.io/controller: system-upgrade-controller # necessary to avoid drain
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      serviceAccountName: {{ include "system-upgrade-controller.serviceAccountName" . }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: system-upgrade-controller
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: default-controller-env
+          env:
+            - name: SYSTEM_UPGRADE_CONTROLLER_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.labels['upgrade.cattle.io/controller']
+            - name: SYSTEM_UPGRADE_CONTROLLER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SYSTEM_UPGRADE_CONTROLLER_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: etc-ssl
+              mountPath: /etc/ssl
+              readOnly: true
+            - name: etc-pki
+              mountPath: /etc/pki
+              readOnly: true
+            - name: etc-ca-certificates
+              mountPath: /etc/ca-certificates
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: etc-ssl
+          hostPath:
+            path: /etc/ssl
+            type: DirectoryOrCreate
+        - name: etc-pki
+          hostPath:
+            path: /etc/pki
+            type: DirectoryOrCreate
+        - name: etc-ca-certificates
+          hostPath:
+            path: /etc/ca-certificates
+            type: DirectoryOrCreate
+        - name: tmp
+          emptyDir: {}

--- a/charts/system-upgrade-controller/templates/namespace.yaml
+++ b/charts/system-upgrade-controller/templates/namespace.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "system-upgrade-controller.namespace" . }}
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/system-upgrade-controller/templates/role.yaml
+++ b/charts/system-upgrade-controller/templates/role.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system-upgrade-controller
+  namespace: {{ include "system-upgrade-controller.namespace" . }}
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/system-upgrade-controller/templates/rolebinding.yaml
+++ b/charts/system-upgrade-controller/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system-upgrade
+  namespace: {{ include "system-upgrade-controller.namespace" . }}
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: system-upgrade-controller
+subjects:
+- kind: ServiceAccount
+  name: {{ include "system-upgrade-controller.serviceAccountName" . }}
+  namespace: {{ include "system-upgrade-controller.namespace" . }}

--- a/charts/system-upgrade-controller/templates/serviceaccount.yaml
+++ b/charts/system-upgrade-controller/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "system-upgrade-controller.serviceAccountName" . }}
+  namespace: {{ include "system-upgrade-controller.namespace" . }}
+  labels:
+    {{- include "system-upgrade-controller.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/system-upgrade-controller/tests/configmap_test.yaml
+++ b/charts/system-upgrade-controller/tests/configmap_test.yaml
@@ -1,0 +1,122 @@
+suite: test ConfigMap
+templates:
+  - configmap.yaml
+tests:
+  - it: should create ConfigMap
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+
+  - it: should have correct name and namespace
+    set:
+      namespace.name: system-upgrade
+    asserts:
+      - equal:
+          path: metadata.name
+          value: default-controller-env
+      - equal:
+          path: metadata.namespace
+          value: system-upgrade
+
+  - it: should have debug setting from values
+    set:
+      controller.debug: true
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_CONTROLLER_DEBUG
+          value: "true"
+
+  - it: should have debug false by default
+    set:
+      controller.debug: false
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_CONTROLLER_DEBUG
+          value: "false"
+
+  - it: should have threads setting from values
+    set:
+      controller.threads: 4
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_CONTROLLER_THREADS
+          value: "4"
+
+  - it: should have default threads value
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_CONTROLLER_THREADS
+          value: "2"
+
+  - it: should have leader elect setting
+    set:
+      controller.leaderElect: false
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_CONTROLLER_LEADER_ELECT
+          value: "false"
+
+  - it: should have job active deadline seconds
+    set:
+      job.activeDeadlineSeconds: 1200
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_JOB_ACTIVE_DEADLINE_SECONDS
+          value: "1200"
+
+  - it: should have job backoff limit
+    set:
+      job.backoffLimit: 50
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_JOB_BACKOFF_LIMIT
+          value: "50"
+
+  - it: should have job image pull policy
+    set:
+      job.imagePullPolicy: IfNotPresent
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_JOB_IMAGE_PULL_POLICY
+          value: IfNotPresent
+
+  - it: should have kubectl image
+    set:
+      job.kubectlImage: rancher/kubectl:v1.30.0
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_JOB_KUBECTL_IMAGE
+          value: rancher/kubectl:v1.30.0
+
+  - it: should have job privileged setting
+    set:
+      job.privileged: false
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_JOB_PRIVILEGED
+          value: "false"
+
+  - it: should have job TTL
+    set:
+      job.ttlSecondsAfterFinish: 600
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_JOB_TTL_SECONDS_AFTER_FINISH
+          value: "600"
+
+  - it: should have plan polling interval
+    set:
+      plan.pollingInterval: 30m
+    asserts:
+      - equal:
+          path: data.SYSTEM_UPGRADE_PLAN_POLLING_INTERVAL
+          value: 30m
+
+  - it: should have standard helm labels
+    asserts:
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+      - isNotNull:
+          path: metadata.labels["app.kubernetes.io/name"]

--- a/charts/system-upgrade-controller/tests/crd_test.yaml
+++ b/charts/system-upgrade-controller/tests/crd_test.yaml
@@ -1,0 +1,84 @@
+suite: test CRD
+templates:
+  - crd.yaml
+tests:
+  - it: should create CRD when enabled
+    set:
+      crd.install: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CustomResourceDefinition
+
+  - it: should not create CRD when disabled
+    set:
+      crd.install: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have correct CRD name
+    set:
+      crd.install: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: plans.upgrade.cattle.io
+
+  - it: should have correct group
+    set:
+      crd.install: true
+    asserts:
+      - equal:
+          path: spec.group
+          value: upgrade.cattle.io
+
+  - it: should have correct scope
+    set:
+      crd.install: true
+    asserts:
+      - equal:
+          path: spec.scope
+          value: Namespaced
+
+  - it: should have correct plural name
+    set:
+      crd.install: true
+    asserts:
+      - equal:
+          path: spec.names.plural
+          value: plans
+
+  - it: should have correct singular name
+    set:
+      crd.install: true
+    asserts:
+      - equal:
+          path: spec.names.singular
+          value: plan
+
+  - it: should have correct kind
+    set:
+      crd.install: true
+    asserts:
+      - equal:
+          path: spec.names.kind
+          value: Plan
+
+  - it: should have v1 version
+    set:
+      crd.install: true
+    asserts:
+      - contains:
+          path: spec.versions
+          content:
+            name: v1
+          any: true
+
+  - it: should have additional printer columns
+    set:
+      crd.install: true
+    asserts:
+      - isNotEmpty:
+          path: spec.versions[0].additionalPrinterColumns

--- a/charts/system-upgrade-controller/tests/deployment_test.yaml
+++ b/charts/system-upgrade-controller/tests/deployment_test.yaml
@@ -1,0 +1,211 @@
+suite: test Deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: should create Deployment
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: should have correct name and namespace
+    set:
+      namespace.name: system-upgrade
+    asserts:
+      - equal:
+          path: metadata.name
+          value: system-upgrade-controller
+      - equal:
+          path: metadata.namespace
+          value: system-upgrade
+
+  - it: should have Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should have correct selector labels
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["upgrade.cattle.io/controller"]
+          value: system-upgrade-controller
+
+  - it: should have pod labels
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: controller
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: system-upgrade-controller
+      - equal:
+          path: spec.template.metadata.labels["upgrade.cattle.io/controller"]
+          value: system-upgrade-controller
+
+  - it: should use correct service account
+    set:
+      serviceAccount.name: system-upgrade
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: system-upgrade
+
+  - it: should have nodeAffinity for control-plane
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution
+
+  - it: should have podAntiAffinity
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution
+
+  - it: should have all tolerations
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "CriticalAddonsOnly"
+            operator: "Exists"
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: "node-role.kubernetes.io/control-plane"
+            operator: "Exists"
+            effect: "NoSchedule"
+
+  - it: should have correct security context
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.runAsGroup
+          value: 65534
+
+  - it: should have container security context
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: should have correct image
+    set:
+      image.repository: test/repo
+      image.tag: v1.0.0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: test/repo:v1.0.0
+
+  - it: should use appVersion as default tag
+    set:
+      image.repository: test/repo
+      image.tag: ""
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^test/repo:v"
+
+  - it: should have envFrom with configMap
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: default-controller-env
+
+  - it: should have env variables from field ref
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SYSTEM_UPGRADE_CONTROLLER_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['upgrade.cattle.io/controller']
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SYSTEM_UPGRADE_CONTROLLER_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+
+  - it: should have all volume mounts
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: etc-ssl
+            mountPath: /etc/ssl
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: etc-pki
+            mountPath: /etc/pki
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tmp
+            mountPath: /tmp
+
+  - it: should have all volumes
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: etc-ssl
+            hostPath:
+              path: /etc/ssl
+              type: DirectoryOrCreate
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tmp
+            emptyDir: {}
+
+  - it: should support custom resources
+    set:
+      resources:
+        requests:
+          memory: "256Mi"
+          cpu: "200m"
+        limits:
+          memory: "512Mi"
+          cpu: "400m"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 256Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 400m
+
+  - it: should support custom pod annotations
+    set:
+      podAnnotations:
+        test: value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.test
+          value: value
+
+  - it: should support custom pod labels
+    set:
+      podLabels:
+        custom: label
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.custom
+          value: label

--- a/charts/system-upgrade-controller/tests/namespace_test.yaml
+++ b/charts/system-upgrade-controller/tests/namespace_test.yaml
@@ -1,0 +1,54 @@
+suite: test Namespace
+templates:
+  - namespace.yaml
+tests:
+  - it: should create namespace when enabled
+    set:
+      namespace.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Namespace
+
+  - it: should not create namespace when disabled
+    set:
+      namespace.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have correct namespace name from values
+    set:
+      namespace.create: true
+      namespace.name: system-upgrade
+    asserts:
+      - equal:
+          path: metadata.name
+          value: system-upgrade
+
+  - it: should support custom namespace name
+    set:
+      namespace.create: true
+      namespace.name: custom-namespace
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-namespace
+
+  - it: should have pod-security label
+    set:
+      namespace.create: true
+    asserts:
+      - equal:
+          path: metadata.labels["pod-security.kubernetes.io/enforce"]
+          value: privileged
+
+  - it: should have standard helm labels
+    set:
+      namespace.create: true
+    asserts:
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+      - isNotNull:
+          path: metadata.labels["app.kubernetes.io/managed-by"]

--- a/charts/system-upgrade-controller/tests/rbac_test.yaml
+++ b/charts/system-upgrade-controller/tests/rbac_test.yaml
@@ -1,0 +1,198 @@
+suite: test RBAC
+templates:
+  - clusterrole.yaml
+  - clusterrole-drainer.yaml
+  - role.yaml
+  - clusterrolebinding.yaml
+  - rolebinding.yaml
+tests:
+  # ClusterRole tests
+  - it: should create main ClusterRole
+    template: clusterrole.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: system-upgrade-controller
+
+  - it: ClusterRole should have batch/jobs permissions
+    template: clusterrole.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["batch"]
+            resources: ["jobs"]
+            verbs: ["get", "list", "watch"]
+
+  - it: ClusterRole should have CRD permissions
+    template: clusterrole.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["get", "list", "watch", "create", "patch", "update"]
+
+  - it: ClusterRole should have plan permissions
+    template: clusterrole.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["upgrade.cattle.io"]
+            resources: ["plans", "plans/status"]
+            verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+
+  # ClusterRole Drainer tests
+  - it: should create drainer ClusterRole
+    template: clusterrole-drainer.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: system-upgrade-controller-drainer
+
+  - it: drainer ClusterRole should have pod eviction permissions
+    template: clusterrole-drainer.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods/eviction"]
+            verbs: ["create"]
+
+  - it: drainer ClusterRole should have node patch permissions
+    template: clusterrole-drainer.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["get", "patch"]
+
+  # Role tests
+  - it: should create Role in namespace
+    template: role.yaml
+    set:
+      namespace.name: system-upgrade
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: system-upgrade-controller
+      - equal:
+          path: metadata.namespace
+          value: system-upgrade
+
+  - it: Role should have job management permissions
+    template: role.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["batch"]
+            resources: ["jobs"]
+            verbs: ["create", "delete", "deletecollection", "patch", "update", "get", "list", "watch"]
+
+  - it: Role should have secret read permissions
+    template: role.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "list", "watch"]
+
+  # ClusterRoleBinding tests
+  - it: should create ClusterRoleBindings
+    template: clusterrolebinding.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should create main ClusterRoleBinding
+    template: clusterrolebinding.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: system-upgrade
+
+  - it: should create drainer ClusterRoleBinding
+    template: clusterrolebinding.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: system-upgrade-drainer
+
+  - it: main ClusterRoleBinding should reference correct role
+    template: clusterrolebinding.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: system-upgrade-controller
+
+  - it: main ClusterRoleBinding should reference service account
+    template: clusterrolebinding.yaml
+    documentIndex: 0
+    set:
+      namespace.name: system-upgrade
+      serviceAccount.name: system-upgrade
+    asserts:
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: system-upgrade
+            namespace: system-upgrade
+
+  # RoleBinding tests
+  - it: should create RoleBinding
+    template: rolebinding.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RoleBinding
+
+  - it: RoleBinding should be in correct namespace
+    template: rolebinding.yaml
+    set:
+      namespace.name: system-upgrade
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: system-upgrade
+
+  - it: RoleBinding should reference correct role
+    template: rolebinding.yaml
+    asserts:
+      - equal:
+          path: roleRef.kind
+          value: Role
+      - equal:
+          path: roleRef.name
+          value: system-upgrade-controller

--- a/charts/system-upgrade-controller/tests/serviceaccount_test.yaml
+++ b/charts/system-upgrade-controller/tests/serviceaccount_test.yaml
@@ -1,0 +1,69 @@
+suite: test ServiceAccount
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should create service account when enabled
+    set:
+      serviceAccount.create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+
+  - it: should not create service account when disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should have correct namespace
+    set:
+      serviceAccount.create: true
+      namespace.name: system-upgrade
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: system-upgrade
+
+  - it: should use default name when not specified
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: ""
+    asserts:
+      - equal:
+          path: metadata.name
+          value: system-upgrade
+
+  - it: should use custom name when specified
+    set:
+      serviceAccount.create: true
+      serviceAccount.name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+
+  - it: should include custom annotations
+    set:
+      serviceAccount.create: true
+      serviceAccount.annotations:
+        foo: bar
+        test: value
+    asserts:
+      - equal:
+          path: metadata.annotations.foo
+          value: bar
+      - equal:
+          path: metadata.annotations.test
+          value: value
+
+  - it: should have standard helm labels
+    set:
+      serviceAccount.create: true
+    asserts:
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+      - isNotNull:
+          path: metadata.labels["app.kubernetes.io/name"]

--- a/charts/system-upgrade-controller/values.schema.json
+++ b/charts/system-upgrade-controller/values.schema.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "System Upgrade Controller Values",
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Image repository"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Image pull policy"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Overrides the image tag whose default is the chart appVersion"
+        }
+      },
+      "required": ["repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Image pull secrets"
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the fullname of the chart"
+    },
+    "namespace": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the namespace"
+        },
+        "create": {
+          "type": "boolean",
+          "description": "Create the namespace"
+        }
+      },
+      "required": ["name", "create"]
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a service account should be created"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations to add to the service account"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the service account to use"
+        }
+      },
+      "required": ["create"]
+    },
+    "controller": {
+      "type": "object",
+      "properties": {
+        "debug": {
+          "type": "boolean",
+          "description": "Enable debug logging"
+        },
+        "threads": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of threads for the controller"
+        },
+        "leaderElect": {
+          "type": "boolean",
+          "description": "Enable leader election"
+        },
+        "name": {
+          "type": "string",
+          "description": "Controller name"
+        }
+      },
+      "required": ["debug", "threads", "leaderElect", "name"]
+    },
+    "job": {
+      "type": "object",
+      "properties": {
+        "activeDeadlineSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Active deadline seconds for jobs"
+        },
+        "backoffLimit": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Backoff limit for job failures"
+        },
+        "imagePullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Image pull policy for upgrade jobs"
+        },
+        "kubectlImage": {
+          "type": "string",
+          "description": "kubectl image for upgrade jobs"
+        },
+        "privileged": {
+          "type": "boolean",
+          "description": "Run upgrade jobs as privileged"
+        },
+        "ttlSecondsAfterFinish": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "TTL seconds after job finish"
+        }
+      },
+      "required": [
+        "activeDeadlineSeconds",
+        "backoffLimit",
+        "imagePullPolicy",
+        "kubectlImage",
+        "privileged",
+        "ttlSecondsAfterFinish"
+      ]
+    },
+    "plan": {
+      "type": "object",
+      "properties": {
+        "pollingInterval": {
+          "type": "string",
+          "description": "Polling interval for checking plan updates"
+        }
+      },
+      "required": ["pollingInterval"]
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Pod annotations"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Pod labels"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the pod"
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context for the container"
+    },
+    "resources": {
+      "type": "object",
+      "description": "Resource limits and requests"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for the controller deployment"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Tolerations for the controller deployment"
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity for the controller deployment"
+    },
+    "crd": {
+      "type": "object",
+      "properties": {
+        "install": {
+          "type": "boolean",
+          "description": "Install the CRD (Plans)"
+        }
+      },
+      "required": ["install"]
+    }
+  },
+  "required": [
+    "image",
+    "namespace",
+    "serviceAccount",
+    "controller",
+    "job",
+    "plan",
+    "crd"
+  ]
+}

--- a/charts/system-upgrade-controller/values.yaml
+++ b/charts/system-upgrade-controller/values.yaml
@@ -1,0 +1,136 @@
+# Default values for system-upgrade-controller
+
+# -- Image configuration
+image:
+  repository: rancher/system-upgrade-controller
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Namespace where the controller will be deployed
+namespace:
+  # -- Name of the namespace
+  name: system-upgrade
+  # -- Create the namespace
+  create: true
+
+# -- Service account configuration
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use
+  name: system-upgrade
+
+# -- Controller configuration
+controller:
+  # -- Enable debug logging
+  debug: false
+  # -- Number of threads for the controller
+  threads: 2
+  # -- Enable leader election
+  leaderElect: true
+  # -- Controller name (from metadata labels)
+  name: system-upgrade-controller
+
+# -- Job configuration for upgrade plans
+job:
+  # -- Active deadline seconds for jobs
+  activeDeadlineSeconds: 900
+  # -- Backoff limit for job failures
+  backoffLimit: 99
+  # -- Image pull policy for upgrade jobs
+  imagePullPolicy: Always
+  # -- kubectl image for upgrade jobs
+  kubectlImage: rancher/kubectl:v1.30.3
+  # -- Run upgrade jobs as privileged
+  privileged: true
+  # -- TTL seconds after job finish
+  ttlSecondsAfterFinish: 900
+
+# -- Plan polling configuration
+plan:
+  # -- Polling interval for checking plan updates
+  pollingInterval: 15m
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Security context for the pod
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 65534
+  runAsGroup: 65534
+
+# -- Security context for the container
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Resource limits and requests
+resources: {}
+  # requests:
+  #   memory: "128Mi"
+  #   cpu: "100m"
+  # limits:
+  #   memory: "256Mi"
+  #   cpu: "200m"
+
+# -- Node selector for the controller deployment
+nodeSelector: {}
+
+# -- Tolerations for the controller deployment
+tolerations:
+  - key: "CriticalAddonsOnly"
+    operator: "Exists"
+  - key: "node-role.kubernetes.io/master"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/controlplane"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/etcd"
+    operator: "Exists"
+    effect: "NoExecute"
+
+# -- Affinity for the controller deployment
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: "node-role.kubernetes.io/control-plane"
+              operator: "Exists"
+            - key: "kubernetes.io/os"
+              operator: "In"
+              values:
+                - "linux"
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: "kubernetes.io/hostname"
+        labelSelector:
+          matchExpressions:
+            - key: "app.kubernetes.io/name"
+              operator: "In"
+              values:
+                - "system-upgrade-controller"
+
+# -- CRD installation
+crd:
+  # -- Install the CRD (Plans)
+  install: true


### PR DESCRIPTION
## Description

Adds a new Helm chart for Rancher's system-upgrade-controller with modern CI/CD practices:

- **Chart implementation**: Complete TDD approach with 76 unit tests (100% passing)
- **OCI publishing**: Modern workflow publishing to GHCR with cosign keyless signing
- **Documentation**: Updated README files with OCI installation instructions

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml` (0.1.0)
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated
- [x] `README.md` has been updated
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory (76 tests total)
- [x] All tests pass locally (`helm unittest charts/system-upgrade-controller`)
- [x] Schema validation passes
- [x] Helm lint passes

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

## Additional context

**Test Coverage**: 6 test files with 76 tests covering all resources
- CRD: 10 tests
- Namespace: 6 tests
- ServiceAccount: 7 tests
- RBAC: 18 tests
- ConfigMap: 15 tests
- Deployment: 20 tests

**Publishing**: New workflow `.github/workflows/publish-system-upgrade-controller.yaml` implements OCI-native publishing with cosign signing and transparency log.

Co-Authored-By: Claude <noreply@anthropic.com>