### PR TITLE
fix: improve cosign signing with verbose logging and verification

### DIFF
--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -111,6 +111,9 @@ jobs:
       - name: Install ORAS
         uses: oras-project/setup-oras@v1
 
+      - name: Install crane
+        uses: imjasonh/setup-crane@v0.4
+
       - name: Install yq
         run: |
           # renovate: datasource=github-releases depName=mikefarah/yq
@@ -226,11 +229,22 @@ jobs:
 
       - name: Sign chart with cosign
         if: steps.check-version.outputs.exists == 'false'
+        env:
+          COSIGN_EXPERIMENTAL: "true"
         run: |
           IMAGE_URI="ghcr.io/${{ github.repository_owner }}/charts/${{ steps.chart-metadata.outputs.name }}@${{ steps.push.outputs.digest }}"
           echo "Signing ${IMAGE_URI}"
-          cosign sign --yes "${IMAGE_URI}"
+          cosign sign --yes --verbose=9 "${IMAGE_URI}"
           echo "Chart signed successfully"
+
+          # Verify signature was created
+          SIG_TAG="sha256-$(echo '${{ steps.push.outputs.digest }}' | cut -d':' -f2).sig"
+          echo "Checking for signature tag: ${SIG_TAG}"
+          if crane manifest "ghcr.io/${{ github.repository_owner }}/charts/${{ steps.chart-metadata.outputs.name }}:${SIG_TAG}" >/dev/null 2>&1; then
+            echo "✓ Signature tag found in registry"
+          else
+            echo "⚠️  Warning: Signature tag not found in registry"
+          fi
 
       - name: Publish Artifact Hub metadata
         if: steps.check-version.outputs.exists == 'false'

--- a/charts/system-upgrade-controller/Chart.yaml
+++ b/charts/system-upgrade-controller/Chart.yaml
@@ -1,12 +1,8 @@
 annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Fix cosign signing to use digest for proper Artifact Hub verification
-    - kind: added
-      description: Add Artifact Hub metadata with keyless signing information
-    - kind: changed
-      description: Improve chart packaging with better .helmignore
+    - kind: fixed
+      description: Fix cosign signature upload to registry with verbose logging and verification
   artifacthub.io/crds: |
     - kind: Plan
       version: v1
@@ -26,7 +22,7 @@ apiVersion: v2
 name: system-upgrade-controller
 description: Kubernetes-native upgrade controller for nodes using declarative Plans
 type: application
-version: "0.1.3"
+version: "0.1.4"
 # renovate: datasource=github-releases depName=rancher/system-upgrade-controller
 appVersion: "v0.17.0"
 icon: https://avatars.githubusercontent.com/u/9343010


### PR DESCRIPTION
## Problem

Cosign signatures were being created locally during CI but not uploaded to the registry, making charts appear as unsigned in Artifact Hub.

## Root Cause

The cosign step was missing:
1.  environment variable
2. Verbose logging to debug upload issues  
3. Post-signing verification

## Solution

- Add  env variable to cosign step
- Add  flag for detailed logging
- Install  tool for signature verification
- Add post-signing check to verify signature tag exists in registry

## Testing

System-upgrade-controller bumped to 0.1.4 to trigger publishing and test the fix.

After merge, signature should be visible at: `ghcr.io/lexfrei/charts/system-upgrade-controller:sha256-<digest>.sig`

## Related

Fixes issue where Artifact Hub shows charts as not signed despite cosign being configured.