### PR TITLE
fix(ci): improve Renovate automerge workflow

### DIFF
--- a/.github/workflows/renovate-update.yaml
+++ b/.github/workflows/renovate-update.yaml
@@ -71,14 +71,6 @@ jobs:
               continue
             fi
 
-            current_version=$(yq eval '.version' "$chart_file")
-            echo "Current chart version: $current_version"
-
-            # Bump patch version
-            new_version=$(echo "$current_version" | awk -F. '{$NF = $NF + 1;} 1' | sed 's/ /./g')
-            echo "Bumping chart version: $current_version -> $new_version"
-            yq eval -i ".version = \"$new_version\"" "$chart_file"
-
             # Extract description from PR title
             # Format: "chore(deps): update rancher/kubectl docker tag to v1.34.1" -> "Update rancher/kubectl docker tag to v1.34.1"
             pr_title="${{ github.event.pull_request.title }}"
@@ -90,7 +82,7 @@ jobs:
             yq eval -i '.annotations."artifacthub.io/changes" = "- kind: changed\n  description: " + env(changelog_desc)' \
               "$chart_file"
 
-            echo "✅ Updated Chart.yaml with version and changelog"
+            echo "✅ Updated Chart.yaml changelog"
 
             # Generate documentation if README.md.gotmpl exists
             if [ -f "$chart_dir/README.md.gotmpl" ]; then

--- a/.github/workflows/renovate-update.yaml
+++ b/.github/workflows/renovate-update.yaml
@@ -113,6 +113,15 @@ jobs:
             git push
           fi
 
+      - name: Enable auto-merge
+        if: steps.update.outputs.changes_made == 'true'
+        run: |
+          echo "Enabling auto-merge for PR #${{ github.event.pull_request.number }}"
+          gh pr merge --auto --squash ${{ github.event.pull_request.number }}
+          echo "✅ Auto-merge enabled, PR will merge automatically when all checks pass"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Trigger tests after bot commit
         if: steps.update.outputs.changes_made == 'true'
         run: |

--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,18 @@
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{depName}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Update container image versions in Helm unit tests",
+      "fileMatch": [
+        "^charts/.+/tests/.+\\.yaml$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?value: [\"'](?<depName>.*?):(?<currentValue>.*?)[\"']"
+      ],
+      "datasourceTemplate": "{{datasource}}",
+      "depNameTemplate": "{{depName}}"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Remove duplicate version bumping from `renovate-update.yaml` (Renovate already handles this)
- Add custom regex manager to automatically update container image versions in Helm unit tests
- **Enable auto-merge on Renovate PRs** after changelog update
- **Enable `allow_auto_merge` in repository settings**
- Fixes automerge failures caused by outdated hardcoded versions in test files

## Problem

PR #89 and similar Renovate PRs were not being auto-merged despite having `automerge: true` configured in `renovate.json`. Root causes:

1. **Double version bumping**: Renovate bumps chart version automatically, then `renovate-update.yaml` bumped it again (0.12.2 → 0.12.3 → 0.12.4)
2. **Test failures**: `charts/cloudflare-tunnel/tests/deployment_test.yaml:33` had hardcoded version `2025.10.0`, but Renovate updated `appVersion` to `2025.10.1`, causing test failure
3. **Blocked automerge**: With `ignoreTests: false`, failed tests prevented automerge
4. **Auto-merge disabled**: Repository had `allow_auto_merge: false`, preventing platform automerge

## Changes

### 1. `.github/workflows/renovate-update.yaml`
- **Removed** lines 74-80: duplicate version bumping logic
- **Added** auto-merge step: `gh pr merge --auto --squash` after changelog update
- Workflow now: updates changelog → enables auto-merge → triggers tests

### 2. `renovate.json`
- **Added** custom regex manager for Helm unit test files
- Automatically updates container image versions in test files matching pattern `# renovate: datasource=... depName=...`
- Matches pattern: `value: "cloudflare/cloudflared:2025.10.0"` → updates to `2025.10.1`

### 3. Repository settings
- **Enabled** `allow_auto_merge` via GitHub API

## Workflow Flow

1. Renovate creates PR with `appVersion` update
2. `renovate-update.yaml` triggers:
   - Updates changelog in `Chart.yaml`
   - Regenerates README.md
   - Commits changes
   - **Enables auto-merge on PR**
   - Triggers test workflow
3. Tests run and pass (versions now match thanks to regex manager)
4. **PR auto-merges automatically** 🎉

## Benefits

- ✅ Renovate PRs will pass tests automatically
- ✅ Auto-merge will work as configured
- ✅ No manual intervention needed for dependency updates
- ✅ Single source of truth for version bumping (Renovate config)
- ✅ Platform auto-merge enabled in repo settings

## Test Plan

- [x] Enable `allow_auto_merge` in repository settings
- [ ] Merge this PR
- [ ] Wait for next Renovate PR or manually trigger one
- [ ] Verify test files are updated automatically
- [ ] Verify tests pass
- [ ] Verify auto-merge is enabled on PR
- [ ] Verify PR auto-merges successfully

## References

- Related issue: PR #89 not auto-merging
- Renovate docs: [Custom Managers](https://docs.renovatebot.com/modules/manager/regex/)