### PR TITLE
fix(renovate): fix duplicate named group in regex manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
         "^charts/.+/tests/.+\\.yaml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?value: [\"'](?<depName>.*?):(?<currentValue>.*?)[\"']"
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?value: [\"'][^:]+:(?<currentValue>.*?)[\"']"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{depName}}"


### PR DESCRIPTION
## Summary

Fix Renovate configuration error caused by duplicate named capture group in custom regex manager.

## Problem

Issue #91: Renovate reported configuration error and stopped creating PRs.

Root cause: In `renovate.json` line 52, the regex pattern used `(?<depName>.*?)` **twice**:

```json
"# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?value: [\"'](?<depName>.*?):(?<currentValue>.*?)[\"']"
```

This is invalid regex - named capture groups must be unique.

## Solution

Changed the second occurrence from `(?<depName>.*?)` to `[^:]+` to match the image name without capturing it:

```json
"# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?value: [\"'][^:]+:(?<currentValue>.*?)[\"']"
```

The `depName` is already captured from the comment, so we only need to match (not capture) it in the value field.

## Testing

- [x] Syntax is valid regex
- [ ] Merge and verify Renovate accepts configuration
- [ ] Verify issue #91 closes automatically

Fixes #91