### PR TITLE
feat(charts): add vipalived chart for keepalived-based VIP management

### DIFF
--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -1,0 +1,31 @@
+annotations:
+  artifacthub.io/category: networking
+  artifacthub.io/changes: |-
+    - kind: added
+      description: Initial release of vipalived chart
+  artifacthub.io/license: BSD-3-Clause
+  artifacthub.io/links: |
+    - name: Chart Repository
+      url: https://github.com/lexfrei/charts/
+    - name: Keepalived
+      url: https://www.keepalived.org/
+  artifacthub.io/signKey: |
+    fingerprint: keyless
+    url: https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master
+apiVersion: v2
+name: vipalived
+description: Keepalived-based VIP management for Kubernetes control plane high availability
+type: application
+version: 0.1.0
+# renovate: datasource=docker depName=alpine
+appVersion: "3.19"
+keywords:
+  - keepalived
+  - vrrp
+  - high-availability
+  - vip
+  - control-plane
+  - load-balancing
+maintainers:
+  - name: lexfrei
+    email: f@lex.la

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -1,0 +1,191 @@
+# vipalived
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.19](https://img.shields.io/badge/AppVersion-3.19-informational?style=flat-square)
+
+Keepalived-based VIP management for Kubernetes control plane high availability
+
+## TL;DR
+
+```bash
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.1.0
+```
+
+## Introduction
+
+This chart deploys keepalived as a DaemonSet on Kubernetes control plane nodes to provide Virtual IP (VIP) functionality for high availability. It uses VRRP (Virtual Router Redundancy Protocol) to manage IP failover between control plane nodes.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- Control plane nodes with label `node-role.kubernetes.io/control-plane: "true"`
+- Network support for VRRP protocol
+
+## Installing the Chart
+
+To install the chart with the release name `my-vipalived`:
+
+```bash
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived
+```
+
+The command deploys vipalived on the Kubernetes cluster with default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-vipalived` deployment:
+
+```bash
+helm uninstall my-vipalived
+```
+
+## Verifying Chart Signature
+
+All charts published to GHCR are signed using cosign. To verify the chart signature:
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/vipalived:0.1.0 \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod assignment |
+| fullnameOverride | string | `""` | Override the full name of the chart |
+| hostNetwork | bool | `true` | Enable host network mode (required for VIP functionality) |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"alpine"` | Container image repository |
+| image.tag | string | `""` | Container image tag (defaults to chart appVersion if not set) |
+| imagePullSecrets | list | `[]` | Image pull secrets for private registries |
+| keepalived.garp.masterDelay | int | `5` | Delay for gratuitous ARP after master transition |
+| keepalived.garp.masterRefresh | int | `10` | Interval for gratuitous ARP refresh on master |
+| keepalived.garp.masterRefreshRepeat | int | `1` | Number of gratuitous ARP packets to send at refresh |
+| keepalived.garp.masterRepeat | int | `5` | Number of gratuitous ARP packets to send at master transition |
+| keepalived.routerId | string | `"vipalived"` | Router identifier for keepalived |
+| keepalived.vrrpInstance.advertInt | int | `1` | Advertisement interval in seconds |
+| keepalived.vrrpInstance.authentication.authPass | string | `"k8s_vip_secret"` | Authentication password (max 8 characters for PASS) |
+| keepalived.vrrpInstance.authentication.authType | string | `"PASS"` | Authentication type (PASS or AH) |
+| keepalived.vrrpInstance.interface | string | `"eth0"` | Network interface to use for VRRP |
+| keepalived.vrrpInstance.name | string | `"VI_CONTROL_PLANE"` | VRRP instance name |
+| keepalived.vrrpInstance.nopreempt | bool | `true` | Enable non-preemptive mode |
+| keepalived.vrrpInstance.priority | int | `100` | VRRP priority (higher values are preferred) |
+| keepalived.vrrpInstance.state | string | `"BACKUP"` | Initial VRRP state (MASTER or BACKUP) |
+| keepalived.vrrpInstance.virtualIpAddress | string | `"172.16.101.101/32"` | Virtual IP address with CIDR notation |
+| keepalived.vrrpInstance.virtualRouterId | int | `51` | Virtual router ID (must be unique in the network) |
+| keepalived.vrrpVersion | int | `3` | VRRP protocol version (2 or 3) |
+| nameOverride | string | `""` | Override the name of the chart |
+| namespace | string | `"kube-system"` | Namespace to deploy vipalived into |
+| nodeSelector | object | `{"node-role.kubernetes.io/control-plane":"true"}` | Node selector for pod assignment |
+| podAnnotations | object | `{}` | Annotations for pods |
+| podLabels | object | `{}` | Additional labels for pods |
+| podSecurityContext | object | `{}` | Security context for the pod |
+| priorityClassName | string | `"system-node-critical"` | Priority class name for pod scheduling |
+| resources | object | `{"limits":{"cpu":"100m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"32Mi"}}` | Resource requests and limits |
+| securityContext | object | `{"capabilities":{"add":["NET_ADMIN","NET_RAW","NET_BROADCAST"]}}` | Security context for the container |
+| tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists"},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/disk-pressure","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/memory-pressure","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/pid-pressure","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/unschedulable","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/network-unavailable","operator":"Exists"}]` | Tolerations for pod assignment |
+| updateStrategy.maxUnavailable | int | `1` | Maximum number of unavailable pods during update |
+| updateStrategy.type | string | `"RollingUpdate"` | Update strategy type |
+
+## Configuration Examples
+
+### Basic Configuration with Custom VIP
+
+```yaml
+keepalived:
+  vrrpInstance:
+    virtualIpAddress: 192.168.1.100/24
+    interface: eth1
+    priority: 150
+    authentication:
+      authPass: mySecret123
+```
+
+### High Priority Master Node
+
+```yaml
+keepalived:
+  vrrpInstance:
+    state: MASTER
+    priority: 255
+    nopreempt: false
+    virtualIpAddress: 10.0.0.100/24
+```
+
+### Custom GARP Settings for Faster Failover
+
+```yaml
+keepalived:
+  garp:
+    masterDelay: 2
+    masterRefresh: 5
+    masterRepeat: 10
+    masterRefreshRepeat: 2
+```
+
+### Custom Resource Limits
+
+```yaml
+resources:
+  limits:
+    cpu: 200m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 64Mi
+```
+
+### Additional Tolerations
+
+```yaml
+tolerations:
+  - key: node.kubernetes.io/custom-taint
+    operator: Exists
+    effect: NoSchedule
+```
+
+## Important Notes
+
+- **Host Network**: This chart requires `hostNetwork: true` to function correctly. The VIP must be accessible on the host network.
+- **Security**: The container requires `NET_ADMIN`, `NET_RAW`, and `NET_BROADCAST` capabilities to manage network interfaces and VRRP.
+- **Priority Class**: Uses `system-node-critical` to ensure the DaemonSet is scheduled even under resource pressure.
+- **Authentication**: The VRRP authentication password (`authPass`) is limited to 8 characters for PASS type authentication.
+- **Unique Router ID**: Ensure `virtualRouterId` is unique within your network segment to avoid conflicts.
+
+## Troubleshooting
+
+### VIP Not Coming Up
+
+1. Check that the network interface specified in `keepalived.vrrpInstance.interface` exists on the nodes
+2. Verify VRRP protocol is not blocked by network policies or firewalls
+3. Check pod logs: `kubectl logs -n kube-system -l app.kubernetes.io/name=vipalived`
+
+### Multiple Masters
+
+If multiple nodes become MASTER:
+1. Verify `virtualRouterId` is unique in your network
+2. Check network connectivity between nodes
+3. Review authentication settings
+
+### Performance Issues
+
+If experiencing slow failover:
+1. Adjust GARP settings for faster advertisement
+2. Reduce `advertInt` for more frequent health checks
+3. Consider increasing container resources
+
+## Links
+
+- [Keepalived Official Documentation](https://www.keepalived.org/)
+- [VRRP RFC 5798](https://datatracker.ietf.org/doc/html/rfc5798)
+- [Chart Repository](https://github.com/lexfrei/charts/)
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| lexfrei | <f@lex.la> |  |
+

--- a/charts/vipalived/README.md.gotmpl
+++ b/charts/vipalived/README.md.gotmpl
@@ -1,0 +1,150 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+## TL;DR
+
+```bash
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version {{ template "chart.version" . }}
+```
+
+## Introduction
+
+This chart deploys keepalived as a DaemonSet on Kubernetes control plane nodes to provide Virtual IP (VIP) functionality for high availability. It uses VRRP (Virtual Router Redundancy Protocol) to manage IP failover between control plane nodes.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- Control plane nodes with label `node-role.kubernetes.io/control-plane: "true"`
+- Network support for VRRP protocol
+
+## Installing the Chart
+
+To install the chart with the release name `my-vipalived`:
+
+```bash
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived
+```
+
+The command deploys vipalived on the Kubernetes cluster with default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-vipalived` deployment:
+
+```bash
+helm uninstall my-vipalived
+```
+
+## Verifying Chart Signature
+
+All charts published to GHCR are signed using cosign. To verify the chart signature:
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/vipalived:{{ template "chart.version" . }} \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Configuration Examples
+
+### Basic Configuration with Custom VIP
+
+```yaml
+keepalived:
+  vrrpInstance:
+    virtualIpAddress: 192.168.1.100/24
+    interface: eth1
+    priority: 150
+    authentication:
+      authPass: mySecret123
+```
+
+### High Priority Master Node
+
+```yaml
+keepalived:
+  vrrpInstance:
+    state: MASTER
+    priority: 255
+    nopreempt: false
+    virtualIpAddress: 10.0.0.100/24
+```
+
+### Custom GARP Settings for Faster Failover
+
+```yaml
+keepalived:
+  garp:
+    masterDelay: 2
+    masterRefresh: 5
+    masterRepeat: 10
+    masterRefreshRepeat: 2
+```
+
+### Custom Resource Limits
+
+```yaml
+resources:
+  limits:
+    cpu: 200m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 64Mi
+```
+
+### Additional Tolerations
+
+```yaml
+tolerations:
+  - key: node.kubernetes.io/custom-taint
+    operator: Exists
+    effect: NoSchedule
+```
+
+## Important Notes
+
+- **Host Network**: This chart requires `hostNetwork: true` to function correctly. The VIP must be accessible on the host network.
+- **Security**: The container requires `NET_ADMIN`, `NET_RAW`, and `NET_BROADCAST` capabilities to manage network interfaces and VRRP.
+- **Priority Class**: Uses `system-node-critical` to ensure the DaemonSet is scheduled even under resource pressure.
+- **Authentication**: The VRRP authentication password (`authPass`) is limited to 8 characters for PASS type authentication.
+- **Unique Router ID**: Ensure `virtualRouterId` is unique within your network segment to avoid conflicts.
+
+## Troubleshooting
+
+### VIP Not Coming Up
+
+1. Check that the network interface specified in `keepalived.vrrpInstance.interface` exists on the nodes
+2. Verify VRRP protocol is not blocked by network policies or firewalls
+3. Check pod logs: `kubectl logs -n kube-system -l app.kubernetes.io/name=vipalived`
+
+### Multiple Masters
+
+If multiple nodes become MASTER:
+1. Verify `virtualRouterId` is unique in your network
+2. Check network connectivity between nodes
+3. Review authentication settings
+
+### Performance Issues
+
+If experiencing slow failover:
+1. Adjust GARP settings for faster advertisement
+2. Reduce `advertInt` for more frequent health checks
+3. Consider increasing container resources
+
+## Links
+
+- [Keepalived Official Documentation](https://www.keepalived.org/)
+- [VRRP RFC 5798](https://datatracker.ietf.org/doc/html/rfc5798)
+- [Chart Repository](https://github.com/lexfrei/charts/)
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}

--- a/charts/vipalived/templates/_helpers.tpl
+++ b/charts/vipalived/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vipalived.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "vipalived.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "vipalived.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "vipalived.labels" -}}
+helm.sh/chart: {{ include "vipalived.chart" . }}
+{{ include "vipalived.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: control-plane
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "vipalived.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "vipalived.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "vipalived.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "vipalived.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/vipalived/templates/configmap.yaml
+++ b/charts/vipalived/templates/configmap.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "vipalived.fullname" . }}-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "vipalived.labels" . | nindent 4 }}
+data:
+  keepalived.conf: |
+    global_defs {
+      router_id {{ .Values.keepalived.routerId }}
+      vrrp_version {{ .Values.keepalived.vrrpVersion }}
+      vrrp_garp_master_delay {{ .Values.keepalived.garp.masterDelay }}
+      vrrp_garp_master_refresh {{ .Values.keepalived.garp.masterRefresh }}
+      vrrp_garp_master_repeat {{ .Values.keepalived.garp.masterRepeat }}
+      vrrp_garp_master_refresh_repeat {{ .Values.keepalived.garp.masterRefreshRepeat }}
+    }
+
+    vrrp_instance {{ .Values.keepalived.vrrpInstance.name }} {
+      state {{ .Values.keepalived.vrrpInstance.state }}
+      interface {{ .Values.keepalived.vrrpInstance.interface }}
+      virtual_router_id {{ .Values.keepalived.vrrpInstance.virtualRouterId }}
+      priority {{ .Values.keepalived.vrrpInstance.priority }}
+      advert_int {{ .Values.keepalived.vrrpInstance.advertInt }}
+      {{- if .Values.keepalived.vrrpInstance.nopreempt }}
+      nopreempt
+      {{- end }}
+      authentication {
+        auth_type {{ .Values.keepalived.vrrpInstance.authentication.authType }}
+        auth_pass {{ .Values.keepalived.vrrpInstance.authentication.authPass }}
+      }
+      virtual_ipaddress {
+        {{ .Values.keepalived.vrrpInstance.virtualIpAddress }}
+      }
+    }

--- a/charts/vipalived/templates/daemonset.yaml
+++ b/charts/vipalived/templates/daemonset.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "vipalived.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "vipalived.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "vipalived.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.updateStrategy.maxUnavailable }}
+    {{- end }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "vipalived.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: keepalived
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              apk add --no-cache keepalived
+              keepalived --dont-fork --log-console --log-detail --dump-conf
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/keepalived
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "vipalived.fullname" . }}-config

--- a/charts/vipalived/tests/all_resources_test.yaml
+++ b/charts/vipalived/tests/all_resources_test.yaml
@@ -1,0 +1,96 @@
+suite: test all resources
+templates:
+  - configmap.yaml
+  - daemonset.yaml
+tests:
+  - it: should create all required resources with default values
+    asserts:
+      - template: configmap.yaml
+        isKind:
+          of: ConfigMap
+      - template: daemonset.yaml
+        isKind:
+          of: DaemonSet
+
+  - it: should have matching labels across resources
+    asserts:
+      - template: configmap.yaml
+        equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: vipalived
+      - template: daemonset.yaml
+        equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: vipalived
+      - template: configmap.yaml
+        equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - template: daemonset.yaml
+        equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+      - template: configmap.yaml
+        isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+      - template: daemonset.yaml
+        isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+
+  - it: should deploy all resources to the same namespace
+    asserts:
+      - template: configmap.yaml
+        equal:
+          path: metadata.namespace
+          value: kube-system
+      - template: daemonset.yaml
+        equal:
+          path: metadata.namespace
+          value: kube-system
+
+  - it: should use consistent naming
+    asserts:
+      - template: configmap.yaml
+        matchRegex:
+          path: metadata.name
+          pattern: "^RELEASE-NAME-vipalived"
+      - template: daemonset.yaml
+        matchRegex:
+          path: metadata.name
+          pattern: "^RELEASE-NAME-vipalived"
+
+  - it: configmap should be referenced by daemonset
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-vipalived-config
+
+  - it: should respect fullnameOverride across all resources
+    set:
+      fullnameOverride: custom-vipalived
+    asserts:
+      - template: configmap.yaml
+        matchRegex:
+          path: metadata.name
+          pattern: "^custom-vipalived"
+      - template: daemonset.yaml
+        matchRegex:
+          path: metadata.name
+          pattern: "^custom-vipalived"
+
+  - it: should deploy to custom namespace when specified
+    set:
+      namespace: production
+    asserts:
+      - template: configmap.yaml
+        equal:
+          path: metadata.namespace
+          value: production
+      - template: daemonset.yaml
+        equal:
+          path: metadata.namespace
+          value: production

--- a/charts/vipalived/tests/configmap_test.yaml
+++ b/charts/vipalived/tests/configmap_test.yaml
@@ -1,0 +1,143 @@
+suite: test configmap
+templates:
+  - configmap.yaml
+tests:
+  - it: should create a ConfigMap with default values
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vipalived-config
+      - equal:
+          path: metadata.namespace
+          value: kube-system
+      - matchRegex:
+          path: metadata.labels["app.kubernetes.io/name"]
+          pattern: vipalived
+      - matchRegex:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          pattern: RELEASE-NAME
+
+  - it: should contain keepalived configuration with default values
+    asserts:
+      - isNotNull:
+          path: data["keepalived.conf"]
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "router_id vipalived"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "vrrp_version 3"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "vrrp_instance VI_CONTROL_PLANE"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "state BACKUP"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "interface eth0"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "priority 100"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "virtual_router_id 51"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "172.16.101.101/32"
+
+  - it: should use custom keepalived configuration when provided
+    set:
+      keepalived:
+        routerId: custom-router
+        vrrpVersion: 2
+        vrrpInstance:
+          name: CUSTOM_INSTANCE
+          state: MASTER
+          interface: eth1
+          priority: 200
+          virtualRouterId: 52
+          advertInt: 2
+          nopreempt: false
+          authentication:
+            authType: AH
+            authPass: custom12
+          virtualIpAddress: 192.168.1.100/24
+    asserts:
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "router_id custom-router"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "vrrp_version 2"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "vrrp_instance CUSTOM_INSTANCE"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "state MASTER"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "interface eth1"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "priority 200"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "virtual_router_id 52"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "advert_int 2"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "auth_type AH"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "192.168.1.100/24"
+
+  - it: should respect custom namespace
+    set:
+      namespace: custom-namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: should include GARP settings in configuration
+    asserts:
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "vrrp_garp_master_delay 5"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "vrrp_garp_master_refresh 10"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "vrrp_garp_master_repeat 5"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "vrrp_garp_master_refresh_repeat 1"
+
+  - it: should include nopreempt when enabled
+    set:
+      keepalived:
+        vrrpInstance:
+          nopreempt: true
+    asserts:
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "nopreempt"
+
+  - it: should not include nopreempt when disabled
+    set:
+      keepalived:
+        vrrpInstance:
+          nopreempt: false
+    asserts:
+      - notMatchRegex:
+          path: data["keepalived.conf"]
+          pattern: "nopreempt"

--- a/charts/vipalived/tests/daemonset_test.yaml
+++ b/charts/vipalived/tests/daemonset_test.yaml
@@ -1,0 +1,285 @@
+suite: test daemonset
+templates:
+  - daemonset.yaml
+  - configmap.yaml
+tests:
+  - it: should create a DaemonSet with default values
+    asserts:
+      - template: daemonset.yaml
+        hasDocuments:
+          count: 1
+      - template: daemonset.yaml
+        isKind:
+          of: DaemonSet
+      - template: daemonset.yaml
+        equal:
+          path: metadata.name
+          value: RELEASE-NAME-vipalived
+      - template: daemonset.yaml
+        equal:
+          path: metadata.namespace
+          value: kube-system
+      - template: daemonset.yaml
+        matchRegex:
+          path: metadata.labels["app.kubernetes.io/name"]
+          pattern: vipalived
+      - template: daemonset.yaml
+        matchRegex:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          pattern: RELEASE-NAME
+      - template: daemonset.yaml
+        matchRegex:
+          path: metadata.labels["app.kubernetes.io/component"]
+          pattern: control-plane
+
+  - it: should have correct selector labels
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: vipalived
+      - template: daemonset.yaml
+        equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should use RollingUpdate strategy by default
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.updateStrategy.type
+          value: RollingUpdate
+      - template: daemonset.yaml
+        equal:
+          path: spec.updateStrategy.rollingUpdate.maxUnavailable
+          value: 1
+
+  - it: should support OnDelete update strategy
+    set:
+      updateStrategy:
+        type: OnDelete
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+      - template: daemonset.yaml
+        isNull:
+          path: spec.updateStrategy.rollingUpdate
+
+  - it: should enable hostNetwork by default
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: should set priorityClassName
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.priorityClassName
+          value: system-node-critical
+
+  - it: should have correct nodeSelector
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.nodeSelector["node-role.kubernetes.io/control-plane"]
+          value: "true"
+
+  - it: should have default tolerations
+    asserts:
+      - template: daemonset.yaml
+        isNotNull:
+          path: spec.template.spec.tolerations
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.tolerations
+          content:
+            key: CriticalAddonsOnly
+            operator: Exists
+
+  - it: should configure container with correct image
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].name
+          value: keepalived
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: alpine:3.19
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should use custom image tag when provided
+    set:
+      image:
+        tag: "3.20"
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].image
+          value: alpine:3.20
+
+  - it: should mount config volume
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /etc/keepalived
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: RELEASE-NAME-vipalived-config
+
+  - it: should have correct security capabilities
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: NET_ADMIN
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: NET_RAW
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.add
+          content: NET_BROADCAST
+
+  - it: should set resource limits and requests
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 100m
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 64Mi
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 50m
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 32Mi
+
+  - it: should support custom resources
+    set:
+      resources:
+        limits:
+          cpu: 200m
+          memory: 128Mi
+        requests:
+          cpu: 100m
+          memory: 64Mi
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
+
+  - it: should support custom podAnnotations
+    set:
+      podAnnotations:
+        custom/annotation: test-value
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.metadata.annotations["custom/annotation"]
+          value: test-value
+
+  - it: should support custom podLabels
+    set:
+      podLabels:
+        custom-label: test-value
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.metadata.labels["custom-label"]
+          value: test-value
+
+  - it: should include configmap checksum annotation
+    asserts:
+      - template: daemonset.yaml
+        isNotNull:
+          path: spec.template.metadata.annotations["checksum/configmap"]
+
+  - it: should support custom namespace
+    set:
+      namespace: custom-namespace
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: should support imagePullSecrets
+    set:
+      imagePullSecrets:
+        - name: my-secret
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-secret
+
+  - it: should support custom affinity
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: custom-key
+                    operator: In
+                    values:
+                      - custom-value
+    asserts:
+      - template: daemonset.yaml
+        isNotNull:
+          path: spec.template.spec.affinity
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: custom-key
+
+  - it: should support podSecurityContext
+    set:
+      podSecurityContext:
+        runAsUser: 1000
+        fsGroup: 2000
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 1000
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: should use fullnameOverride when provided
+    set:
+      fullnameOverride: custom-name
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: metadata.name
+          value: custom-name

--- a/charts/vipalived/values.schema.json
+++ b/charts/vipalived/values.schema.json
@@ -1,0 +1,237 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of the chart"
+    },
+    "namespace": {
+      "type": "string",
+      "description": "Namespace to deploy vipalived into",
+      "default": "kube-system"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Image pull policy"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Container image tag"
+        }
+      },
+      "required": ["repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Image pull secrets for private registries"
+    },
+    "keepalived": {
+      "type": "object",
+      "properties": {
+        "routerId": {
+          "type": "string",
+          "description": "Router identifier for keepalived"
+        },
+        "vrrpVersion": {
+          "type": "integer",
+          "enum": [2, 3],
+          "description": "VRRP protocol version"
+        },
+        "garp": {
+          "type": "object",
+          "properties": {
+            "masterDelay": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Delay for gratuitous ARP after master transition"
+            },
+            "masterRefresh": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Interval for gratuitous ARP refresh on master"
+            },
+            "masterRepeat": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of gratuitous ARP packets to send at master transition"
+            },
+            "masterRefreshRepeat": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Number of gratuitous ARP packets to send at refresh"
+            }
+          },
+          "required": ["masterDelay", "masterRefresh", "masterRepeat", "masterRefreshRepeat"]
+        },
+        "vrrpInstance": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "VRRP instance name"
+            },
+            "state": {
+              "type": "string",
+              "enum": ["MASTER", "BACKUP"],
+              "description": "Initial VRRP state"
+            },
+            "interface": {
+              "type": "string",
+              "description": "Network interface to use for VRRP"
+            },
+            "priority": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 255,
+              "description": "VRRP priority"
+            },
+            "virtualRouterId": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 255,
+              "description": "Virtual router ID"
+            },
+            "advertInt": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Advertisement interval in seconds"
+            },
+            "nopreempt": {
+              "type": "boolean",
+              "description": "Enable non-preemptive mode"
+            },
+            "authentication": {
+              "type": "object",
+              "properties": {
+                "authType": {
+                  "type": "string",
+                  "enum": ["PASS", "AH"],
+                  "description": "Authentication type"
+                },
+                "authPass": {
+                  "type": "string",
+                  "maxLength": 8,
+                  "description": "Authentication password"
+                }
+              },
+              "required": ["authType", "authPass"]
+            },
+            "virtualIpAddress": {
+              "type": "string",
+              "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$",
+              "description": "Virtual IP address with CIDR notation"
+            }
+          },
+          "required": ["name", "state", "interface", "priority", "virtualRouterId", "advertInt", "nopreempt", "authentication", "virtualIpAddress"]
+        }
+      },
+      "required": ["routerId", "vrrpVersion", "garp", "vrrpInstance"]
+    },
+    "updateStrategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["RollingUpdate", "OnDelete"],
+          "description": "Update strategy type"
+        },
+        "maxUnavailable": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of unavailable pods during update"
+        }
+      },
+      "required": ["type"]
+    },
+    "hostNetwork": {
+      "type": "boolean",
+      "description": "Enable host network mode"
+    },
+    "priorityClassName": {
+      "type": "string",
+      "description": "Priority class name for pod scheduling"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod assignment"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Tolerations for pod assignment"
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod assignment"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the pod"
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context for the container"
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "description": "Resource requests and limits"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Additional labels for pods"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations for pods"
+    }
+  },
+  "required": [
+    "namespace",
+    "image",
+    "keepalived",
+    "hostNetwork",
+    "priorityClassName"
+  ]
+}

--- a/charts/vipalived/values.yaml
+++ b/charts/vipalived/values.yaml
@@ -1,0 +1,135 @@
+# Default values for vipalived.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Override the name of the chart
+nameOverride: ""
+
+# -- Override the full name of the chart
+fullnameOverride: ""
+
+# -- Namespace to deploy vipalived into
+namespace: kube-system
+
+image:
+  # -- Container image repository
+  repository: alpine
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Container image tag (defaults to chart appVersion if not set)
+  tag: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+keepalived:
+  # -- Router identifier for keepalived
+  routerId: vipalived
+  # -- VRRP protocol version (2 or 3)
+  vrrpVersion: 3
+
+  garp:
+    # -- Delay for gratuitous ARP after master transition
+    masterDelay: 5
+    # -- Interval for gratuitous ARP refresh on master
+    masterRefresh: 10
+    # -- Number of gratuitous ARP packets to send at master transition
+    masterRepeat: 5
+    # -- Number of gratuitous ARP packets to send at refresh
+    masterRefreshRepeat: 1
+
+  vrrpInstance:
+    # -- VRRP instance name
+    name: VI_CONTROL_PLANE
+    # -- Initial VRRP state (MASTER or BACKUP)
+    state: BACKUP
+    # -- Network interface to use for VRRP
+    interface: eth0
+    # -- VRRP priority (higher values are preferred)
+    priority: 100
+    # -- Virtual router ID (must be unique in the network)
+    virtualRouterId: 51
+    # -- Advertisement interval in seconds
+    advertInt: 1
+    # -- Enable non-preemptive mode
+    nopreempt: true
+
+    authentication:
+      # -- Authentication type (PASS or AH)
+      authType: PASS
+      # -- Authentication password (max 8 characters for PASS)
+      authPass: k8s_vip
+
+    # -- Virtual IP address with CIDR notation
+    virtualIpAddress: 172.16.101.101/32
+
+updateStrategy:
+  # -- Update strategy type
+  type: RollingUpdate
+  # -- Maximum number of unavailable pods during update
+  maxUnavailable: 1
+
+# -- Enable host network mode (required for VIP functionality)
+hostNetwork: true
+
+# -- Priority class name for pod scheduling
+priorityClassName: system-node-critical
+
+# -- Node selector for pod assignment
+nodeSelector:
+  node-role.kubernetes.io/control-plane: "true"
+
+# -- Tolerations for pod assignment
+tolerations:
+  - key: CriticalAddonsOnly
+    operator: Exists
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/disk-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/memory-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/pid-pressure
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/unschedulable
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/network-unavailable
+    operator: Exists
+
+# -- Affinity rules for pod assignment
+affinity: {}
+
+# -- Security context for the pod
+podSecurityContext: {}
+
+# -- Security context for the container
+securityContext:
+  capabilities:
+    add:
+      - NET_ADMIN
+      - NET_RAW
+      - NET_BROADCAST
+
+# -- Resource requests and limits
+resources:
+  limits:
+    cpu: 100m
+    memory: 64Mi
+  requests:
+    cpu: 50m
+    memory: 32Mi
+
+# -- Additional labels for pods
+podLabels: {}
+
+# -- Annotations for pods
+podAnnotations: {}


### PR DESCRIPTION
## Description

Add new Helm chart for deploying keepalived as a DaemonSet on Kubernetes control plane nodes. This chart provides Virtual IP (VIP) functionality for high availability using the VRRP protocol.

The chart is based on existing manifests from `/Users/lex/git/github.com/lexfrei/k8s/manifests/vipalived` and follows all repository standards.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml` (0.1.0)
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/vipalived`) - 36/36 tests passed
- [x] Schema validation passes (`check-jsonschema --schemafile charts/vipalived/values.schema.json charts/vipalived/values.yaml`)
- [x] Helm lint passes (`helm lint charts/vipalived`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

## Additional context

**Chart Features:**
- Full VRRP configuration (state, priority, virtual router ID, authentication)
- Customizable GARP settings for faster failover
- hostNetwork mode with NET_ADMIN, NET_RAW, NET_BROADCAST capabilities
- Configurable resources, tolerations, and node selection
- system-node-critical priority class
- Comprehensive testing (36 unit tests covering all functionality)
- JSON Schema validation
- Auto-generated documentation via helm-docs

**Validation Results:**
- ✅ helm lint: PASSED
- ✅ check-jsonschema: PASSED  
- ✅ helm unittest: 36/36 tests PASSED
- ✅ helm template: renders correctly

**Chart Version:** 0.1.0  
**AppVersion:** 3.19 (Alpine)