### PR TITLE
feat(vipalived): add Artifact Hub repository metadata for verified badge

### DIFF
--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -1,8 +1,8 @@
 annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update alpine docker tag to v3.22
+    - kind: added
+      description: Add Artifact Hub repository metadata for verified badge
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +16,7 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.2.0
+version: 0.2.1
 # renovate: datasource=docker depName=alpine
 appVersion: "3.22"
 keywords:

--- a/charts/vipalived/artifacthub-repo.yml
+++ b/charts/vipalived/artifacthub-repo.yml
@@ -1,0 +1,7 @@
+# Artifact Hub repository metadata
+# See: https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support
+
+repositoryID: 91b6c014-183f-486e-9cce-f05f2897312e
+owners:
+  - name: Aleksei Sviridkin
+    email: f@lex.la

--- a/charts/vipalived/tests/daemonset_test.yaml
+++ b/charts/vipalived/tests/daemonset_test.yaml
@@ -109,7 +109,8 @@ tests:
       - template: daemonset.yaml
         equal:
           path: spec.template.spec.containers[0].image
-          value: alpine:3.19
+          # renovate: datasource=docker depName=alpine
+          value: alpine:3.22
       - template: daemonset.yaml
         equal:
           path: spec.template.spec.containers[0].imagePullPolicy


### PR DESCRIPTION
## Description

Add `artifacthub-repo.yml` with repository ID `91b6c014-183f-486e-9cce-f05f2897312e` to enable the verified badge on Artifact Hub.

This metadata file:
- Identifies repository ownership
- Enables the "verified" badge on Artifact Hub
- Will be published to OCI registry with tag `artifacthub.io`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml` (0.2.0 → 0.2.1)
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] All tests pass locally (`helm unittest charts/vipalived`) - 36/36 tests passed
- [x] Schema validation passes (`check-jsonschema`)
- [x] Helm lint passes (`helm lint charts/vipalived`)

## Additional context

**Validation Results:**
- ✅ helm lint: PASSED
- ✅ check-jsonschema: PASSED  
- ✅ helm unittest: 36/36 tests PASSED

After this PR is merged, the chart will be republished with the Artifact Hub metadata, enabling the verified badge.