### PR TITLE
feat(vipalived): add static pod mode for Day 1 cluster bootstrap

### DIFF
--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -264,32 +264,10 @@ jobs:
 
           CHANGELOG_RAW=$(yq eval '.annotations."artifacthub.io/changes"' "${CHART_PATH}/Chart.yaml")
 
-          RELEASE_BODY="## Chart: ${CHART_NAME} v${CHART_VERSION}
-
-          **App Version**: ${APP_VERSION}
-
-          ### Installation
-
-          \`\`\`bash
-          helm install ${CHART_NAME} \\
-            oci://ghcr.io/${{ github.repository_owner }}/charts/${CHART_NAME} \\
-            --version ${CHART_VERSION}
-          \`\`\`
-
-          ### Verification
-
-          \`\`\`bash
-          cosign verify \\
-            ghcr.io/${{ github.repository_owner }}/charts/${CHART_NAME}:${CHART_VERSION} \\
-            --certificate-identity \"https://github.com/${{ github.repository }}/.github/workflows/publish-oci.yaml@refs/heads/master\" \\
-            --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\"
-          \`\`\`
-          "
-
+          # Build changelog section first
+          CHANGELOG_SECTION=""
           if [ "$CHANGELOG_RAW" != "null" ] && [ -n "$CHANGELOG_RAW" ]; then
-            RELEASE_BODY="${RELEASE_BODY}
-
-          ### Changelog
+            CHANGELOG_SECTION="### Changelog
 
           "
             TEMP_FILE=$(mktemp)
@@ -320,14 +298,36 @@ jobs:
                   emoji="📝"
                   ;;
               esac
-              RELEASE_BODY="${RELEASE_BODY}- ${emoji} ${description}
+              CHANGELOG_SECTION="${CHANGELOG_SECTION}- ${emoji} ${description}
           "
             done < "$TEMP_FILE"
 
             rm -f "$TEMP_FILE"
+            CHANGELOG_SECTION="${CHANGELOG_SECTION}
+          "
           fi
 
-          RELEASE_BODY="${RELEASE_BODY}
+          # Build release body with changelog first
+          RELEASE_BODY="## Chart: ${CHART_NAME} v${CHART_VERSION}
+
+          **App Version**: ${APP_VERSION}
+
+          ${CHANGELOG_SECTION}### Installation
+
+          \`\`\`bash
+          helm install ${CHART_NAME} \\
+            oci://ghcr.io/${{ github.repository_owner }}/charts/${CHART_NAME} \\
+            --version ${CHART_VERSION}
+          \`\`\`
+
+          ### Verification
+
+          \`\`\`bash
+          cosign verify \\
+            ghcr.io/${{ github.repository_owner }}/charts/${CHART_NAME}:${CHART_VERSION} \\
+            --certificate-identity \"https://github.com/${{ github.repository }}/.github/workflows/publish-oci.yaml@refs/heads/master\" \\
+            --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\"
+          \`\`\`
 
           ---
 

--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -2,7 +2,13 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
     - kind: added
-      description: Add Day 1 bootstrap and Day 2 operations deployment scenarios documentation
+      description: Add static pod mode (static=true) for Day 1 cluster bootstrap with embedded configuration
+    - kind: fixed
+      description: Fix static pod deployment - ConfigMaps don't work with static pods, now config is embedded in command
+    - kind: changed
+      description: Release changelog now appears first in GitHub releases (before installation instructions)
+    - kind: changed
+      description: Refactor keepalived.conf generation into reusable helper template
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +22,7 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.2.3
+version: 0.3.0
 # renovate: datasource=docker depName=alpine
 appVersion: "3.22"
 keywords:

--- a/charts/vipalived/README.md.gotmpl
+++ b/charts/vipalived/README.md.gotmpl
@@ -7,18 +7,26 @@
 ## TL;DR
 
 ```bash
-# Install with default VIP (172.16.101.101/32)
+# Day 2: Install with default VIP (172.16.101.101/32) on existing cluster
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version {{ template "chart.version" . }}
 
-# Install with custom VIP address
+# Day 2: Install with custom VIP address
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived \
   --version {{ template "chart.version" . }} \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
+
+# Day 1: Generate static pod manifest for cluster bootstrap
+helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
+  --version {{ template "chart.version" . }} \
+  --set static=true \
+  --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
 ```
 
 ## Introduction
 
 This chart deploys keepalived as a DaemonSet on Kubernetes control plane nodes to provide Virtual IP (VIP) functionality for high availability. It uses VRRP (Virtual Router Redundancy Protocol) to manage IP failover between control plane nodes.
+
+**Target Audience**: This chart is for users who prefer Kubernetes-native solutions with minimal system intrusion, but need a VIP for the kube-apiserver available before CNI initialization. Unlike kube-vip, Cilium, or other solutions that require CNI or complex integrations, this provides a simple, focused solution specifically for control plane VIP management during cluster bootstrap (Day 1) and beyond (Day 2).
 
 ## Prerequisites
 
@@ -55,34 +63,28 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 
 **How to deploy as static pod:**
 
-1. Render the chart to static YAML manifests:
+1. Render the chart in static pod mode:
 
    ```bash
    helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
      --version {{ template "chart.version" . }} \
+     --set static=true \
      --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR \
-     --namespace kube-system > vipalived-manifests.yaml
+     --namespace kube-system > vipalived-static-pod.yaml
    ```
 
-2. Extract only the DaemonSet and convert it to a static pod manifest:
+   When `static=true`, the chart generates a Pod manifest (instead of DaemonSet) with keepalived configuration embedded directly in the command (no ConfigMap needed).
 
-   ```bash
-   # Extract the DaemonSet spec.template.spec section
-   # This contains the pod specification without DaemonSet wrapper
-   kubectl apply --dry-run=client -f vipalived-manifests.yaml -o yaml | \
-     yq eval 'select(.kind == "DaemonSet") | .spec.template' - > vipalived-pod.yaml
-   ```
-
-3. Copy the static pod manifest to each control plane node:
+2. Copy the static pod manifest to each control plane node:
 
    ```bash
    # On each control plane node
-   sudo cp vipalived-pod.yaml /etc/kubernetes/manifests/vipalived.yaml
+   sudo cp vipalived-static-pod.yaml /etc/kubernetes/manifests/vipalived.yaml
    ```
 
-4. The kubelet will automatically start the static pod within seconds.
+3. The kubelet will automatically start the static pod within seconds.
 
-5. Verify the static pod is running:
+4. Verify the static pod is running:
 
    ```bash
    # Static pods appear with the node name suffix

--- a/charts/vipalived/templates/_helpers.tpl
+++ b/charts/vipalived/templates/_helpers.tpl
@@ -61,3 +61,36 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate keepalived.conf content
+This helper is used by both ConfigMap (for DaemonSet) and Pod (for static pod mode)
+*/}}
+{{- define "vipalived.keepalivedConfig" -}}
+global_defs {
+  router_id {{ .Values.keepalived.routerId }}
+  vrrp_version {{ .Values.keepalived.vrrpVersion }}
+  vrrp_garp_master_delay {{ .Values.keepalived.garp.masterDelay }}
+  vrrp_garp_master_refresh {{ .Values.keepalived.garp.masterRefresh }}
+  vrrp_garp_master_repeat {{ .Values.keepalived.garp.masterRepeat }}
+  vrrp_garp_master_refresh_repeat {{ .Values.keepalived.garp.masterRefreshRepeat }}
+}
+
+vrrp_instance {{ .Values.keepalived.vrrpInstance.name }} {
+  state {{ .Values.keepalived.vrrpInstance.state }}
+  interface {{ .Values.keepalived.vrrpInstance.interface }}
+  virtual_router_id {{ .Values.keepalived.vrrpInstance.virtualRouterId }}
+  priority {{ .Values.keepalived.vrrpInstance.priority }}
+  advert_int {{ .Values.keepalived.vrrpInstance.advertInt }}
+  {{- if .Values.keepalived.vrrpInstance.nopreempt }}
+  nopreempt
+  {{- end }}
+  authentication {
+    auth_type {{ .Values.keepalived.vrrpInstance.authentication.authType }}
+    auth_pass {{ .Values.keepalived.vrrpInstance.authentication.authPass }}
+  }
+  virtual_ipaddress {
+    {{ .Values.keepalived.vrrpInstance.virtualIpAddress }}
+  }
+}
+{{- end }}

--- a/charts/vipalived/templates/configmap.yaml
+++ b/charts/vipalived/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.static }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,29 +8,5 @@ metadata:
     {{- include "vipalived.labels" . | nindent 4 }}
 data:
   keepalived.conf: |
-    global_defs {
-      router_id {{ .Values.keepalived.routerId }}
-      vrrp_version {{ .Values.keepalived.vrrpVersion }}
-      vrrp_garp_master_delay {{ .Values.keepalived.garp.masterDelay }}
-      vrrp_garp_master_refresh {{ .Values.keepalived.garp.masterRefresh }}
-      vrrp_garp_master_repeat {{ .Values.keepalived.garp.masterRepeat }}
-      vrrp_garp_master_refresh_repeat {{ .Values.keepalived.garp.masterRefreshRepeat }}
-    }
-
-    vrrp_instance {{ .Values.keepalived.vrrpInstance.name }} {
-      state {{ .Values.keepalived.vrrpInstance.state }}
-      interface {{ .Values.keepalived.vrrpInstance.interface }}
-      virtual_router_id {{ .Values.keepalived.vrrpInstance.virtualRouterId }}
-      priority {{ .Values.keepalived.vrrpInstance.priority }}
-      advert_int {{ .Values.keepalived.vrrpInstance.advertInt }}
-      {{- if .Values.keepalived.vrrpInstance.nopreempt }}
-      nopreempt
-      {{- end }}
-      authentication {
-        auth_type {{ .Values.keepalived.vrrpInstance.authentication.authType }}
-        auth_pass {{ .Values.keepalived.vrrpInstance.authentication.authPass }}
-      }
-      virtual_ipaddress {
-        {{ .Values.keepalived.vrrpInstance.virtualIpAddress }}
-      }
-    }
+    {{- include "vipalived.keepalivedConfig" . | nindent 4 }}
+{{- end }}

--- a/charts/vipalived/templates/daemonset.yaml
+++ b/charts/vipalived/templates/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.static }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -77,3 +78,4 @@ spec:
         - name: config
           configMap:
             name: {{ include "vipalived.fullname" . }}-config
+{{- end }}

--- a/charts/vipalived/templates/pod.yaml
+++ b/charts/vipalived/templates/pod.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.static }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "vipalived.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "vipalived.labels" . | nindent 4 }}
+    {{- with .Values.podLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  hostNetwork: {{ .Values.hostNetwork }}
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.priorityClassName }}
+  priorityClassName: {{ .Values.priorityClassName }}
+  {{- end }}
+  {{- with .Values.podSecurityContext }}
+  securityContext:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: keepalived
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command:
+        - /bin/sh
+        - -c
+        - |
+          apk add --no-cache keepalived
+          cat > /etc/keepalived/keepalived.conf <<'EOF'
+          {{- include "vipalived.keepalivedConfig" . | nindent 10 }}
+          EOF
+          keepalived --dont-fork --log-console --log-detail --dump-conf
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/vipalived/tests/all_resources_test.yaml
+++ b/charts/vipalived/tests/all_resources_test.yaml
@@ -2,6 +2,7 @@ suite: test all resources
 templates:
   - configmap.yaml
   - daemonset.yaml
+  - pod.yaml
 tests:
   - it: should create all required resources with default values
     asserts:
@@ -91,6 +92,70 @@ tests:
           path: metadata.namespace
           value: production
       - template: daemonset.yaml
+        equal:
+          path: metadata.namespace
+          value: production
+
+  - it: should create Pod instead of DaemonSet when static is true
+    set:
+      static: true
+    asserts:
+      - template: configmap.yaml
+        hasDocuments:
+          count: 0
+      - template: daemonset.yaml
+        hasDocuments:
+          count: 0
+      - template: pod.yaml
+        hasDocuments:
+          count: 1
+      - template: pod.yaml
+        isKind:
+          of: Pod
+
+  - it: should create DaemonSet and ConfigMap when static is false (default)
+    set:
+      static: false
+    asserts:
+      - template: configmap.yaml
+        hasDocuments:
+          count: 1
+      - template: daemonset.yaml
+        hasDocuments:
+          count: 1
+      - template: pod.yaml
+        hasDocuments:
+          count: 0
+
+  - it: static pod should have consistent labels
+    set:
+      static: true
+    asserts:
+      - template: pod.yaml
+        equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: vipalived
+      - template: pod.yaml
+        equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: static pod should respect fullnameOverride
+    set:
+      static: true
+      fullnameOverride: custom-vipalived
+    asserts:
+      - template: pod.yaml
+        equal:
+          path: metadata.name
+          value: custom-vipalived
+
+  - it: static pod should deploy to custom namespace
+    set:
+      static: true
+      namespace: production
+    asserts:
+      - template: pod.yaml
         equal:
           path: metadata.namespace
           value: production

--- a/charts/vipalived/tests/pod_test.yaml
+++ b/charts/vipalived/tests/pod_test.yaml
@@ -1,0 +1,213 @@
+suite: test static pod
+templates:
+  - pod.yaml
+tests:
+  - it: should create Pod when static is true
+    set:
+      static: true
+      keepalived:
+        routerId: test-router
+        vrrpVersion: 3
+        vrrpInstance:
+          virtualIpAddress: 192.168.1.100/24
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Pod
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-vipalived
+
+  - it: should not create Pod when static is false
+    set:
+      static: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should embed configuration in command
+    set:
+      static: true
+      keepalived:
+        routerId: test-router
+        vrrpVersion: 3
+        vrrpInstance:
+          name: TEST_INSTANCE
+          virtualIpAddress: 192.168.1.100/24
+          virtualRouterId: 99
+    asserts:
+      - contains:
+          path: spec.containers[0].command
+          content: /bin/sh
+      - contains:
+          path: spec.containers[0].command
+          content: -c
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "router_id test-router"
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "vrrp_instance TEST_INSTANCE"
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "192.168.1.100/24"
+
+  - it: should use hostNetwork
+    set:
+      static: true
+      hostNetwork: true
+    asserts:
+      - equal:
+          path: spec.hostNetwork
+          value: true
+
+  - it: should apply custom labels
+    set:
+      static: true
+      podLabels:
+        custom: label
+    asserts:
+      - equal:
+          path: metadata.labels.custom
+          value: label
+
+  - it: should apply custom annotations
+    set:
+      static: true
+      podAnnotations:
+        custom: annotation
+    asserts:
+      - equal:
+          path: metadata.annotations.custom
+          value: annotation
+
+  - it: should use correct image
+    set:
+      static: true
+      image:
+        repository: alpine
+        tag: "3.22"
+    asserts:
+      - equal:
+          path: spec.containers[0].image
+          value: alpine:3.22
+
+  - it: should not have ConfigMap volumes
+    set:
+      static: true
+    asserts:
+      - isNull:
+          path: spec.volumes
+
+  - it: should not have ConfigMap volumeMounts
+    set:
+      static: true
+    asserts:
+      - isNull:
+          path: spec.containers[0].volumeMounts
+
+  - it: should apply security context
+    set:
+      static: true
+      securityContext:
+        capabilities:
+          add:
+            - NET_ADMIN
+    asserts:
+      - equal:
+          path: spec.containers[0].securityContext.capabilities.add[0]
+          value: NET_ADMIN
+
+  - it: should apply resources
+    set:
+      static: true
+      resources:
+        requests:
+          memory: "64Mi"
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.memory
+          value: "64Mi"
+
+  - it: should apply nodeSelector
+    set:
+      static: true
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
+    asserts:
+      - equal:
+          path: spec.nodeSelector
+          value:
+            node-role.kubernetes.io/control-plane: "true"
+
+  - it: should apply tolerations
+    set:
+      static: true
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.tolerations
+          content:
+            key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
+
+  - it: should apply affinity
+    set:
+      static: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+    asserts:
+      - isNotNull:
+          path: spec.affinity.nodeAffinity
+
+  - it: should apply priorityClassName
+    set:
+      static: true
+      priorityClassName: system-node-critical
+    asserts:
+      - equal:
+          path: spec.priorityClassName
+          value: system-node-critical
+
+  - it: should apply imagePullSecrets
+    set:
+      static: true
+      imagePullSecrets:
+        - name: regcred
+    asserts:
+      - contains:
+          path: spec.imagePullSecrets
+          content:
+            name: regcred
+
+  - it: should embed nopreempt when enabled
+    set:
+      static: true
+      keepalived:
+        vrrpInstance:
+          nopreempt: true
+          virtualIpAddress: 192.168.1.100/24
+    asserts:
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "nopreempt"
+
+  - it: should not embed nopreempt when disabled
+    set:
+      static: true
+      keepalived:
+        vrrpInstance:
+          nopreempt: false
+          virtualIpAddress: 192.168.1.100/24
+    asserts:
+      - notMatchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "\\s+nopreempt"

--- a/charts/vipalived/values.schema.json
+++ b/charts/vipalived/values.schema.json
@@ -15,6 +15,11 @@
       "description": "Namespace to deploy vipalived into",
       "default": "kube-system"
     },
+    "static": {
+      "type": "boolean",
+      "description": "Enable static pod mode for Day 1 cluster bootstrap. When true, renders a Pod manifest instead of DaemonSet with embedded configuration.",
+      "default": false
+    },
     "image": {
       "type": "object",
       "properties": {

--- a/charts/vipalived/values.yaml
+++ b/charts/vipalived/values.yaml
@@ -11,6 +11,12 @@ fullnameOverride: ""
 # -- Namespace to deploy vipalived into
 namespace: kube-system
 
+# -- Enable static pod mode for Day 1 cluster bootstrap.
+# When true, renders a Pod manifest instead of DaemonSet with embedded configuration.
+# Use this for pre-CNI VIP availability during initial cluster setup.
+# For Day 2 operations (existing cluster), keep this false (default).
+static: false
+
 image:
   # -- Container image repository
   repository: alpine


### PR DESCRIPTION
## Summary

This PR adds static pod mode support to the vipalived chart, enabling Day 1 cluster bootstrap scenarios where the VIP needs to be available before the Kubernetes API server is accessible.

## Changes

### Core Features
- ✨ Add `static: true` flag to enable static pod rendering
- ✨ Create `pod.yaml` template for static pod mode with embedded configuration
- 🔄 Refactor keepalived.conf generation into reusable helper template
- 🐛 Fix static pod deployment - ConfigMaps don't work with static pods, now config is embedded in command via heredoc

### Workflow & Release
- 🔄 Release changelog now appears first in GitHub releases (before installation instructions)

### Documentation
- 📝 Simplify Day 1 deployment instructions - just use `--set static=true`
- 📝 Add target audience description explaining use case vs kube-vip/Cilium
- 📝 Update TL;DR with Day 1 static pod example

### Testing
- ✅ Add comprehensive test suite for static pod mode (18 new tests)
- ✅ Update all_resources_test.yaml to cover both modes
- ✅ All 59 tests passing

## Technical Details

### Problem
Static pods (managed by kubelet in `/etc/kubernetes/manifests/`) cannot use ConfigMaps because:
1. During Day 1 bootstrap, the API server isn't running yet
2. kubelet doesn't fetch ConfigMaps from the API server for static pods

Previous documentation incorrectly instructed users to extract DaemonSet spec, which would fail with ConfigMap mount errors.

### Solution
When `static: true`:
- Chart renders a `Pod` manifest instead of `DaemonSet`
- ConfigMap is not generated
- keepalived configuration is embedded directly in the pod's `command` using heredoc:
  ```yaml
  command:
    - /bin/sh
    - -c
    - |
      cat > /etc/keepalived/keepalived.conf <<'EOF'
      <embedded config>
      EOF
      keepalived --dont-fork ...
  ```

### Usage

**Day 2 (existing cluster) - unchanged:**
```bash
helm install vipalived oci://ghcr.io/lexfrei/charts/vipalived \
  --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
```

**Day 1 (cluster bootstrap) - simplified:**
```bash
helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
  --set static=true \
  --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
```

## Testing

All validations passing:
- ✅ `helm lint` - PASSED
- ✅ `helm unittest` - 59/59 tests PASSED (4 test suites)
- ✅ `check-jsonschema` - PASSED
- ✅ `markdownlint` - PASSED
- ✅ `helm template` (both modes) - renders correctly

## Checklist

- [x] Chart version bumped to 0.3.0 (minor - new feature)
- [x] `artifacthub.io/changes` annotation updated in Chart.yaml
- [x] Tests added/updated for new functionality
- [x] All tests passing
- [x] Documentation updated (README.md)
- [x] values.schema.json updated
- [x] Backward compatible (default `static: false`)

## Version

- **Current**: 0.2.3
- **New**: 0.3.0

## Related Issues/PRs

- #93 - Initial vipalived chart implementation
- #96 - virtualIpAddress documentation improvements
- #97 - Day 1/Day 2 deployment scenarios documentation