### PR TITLE
fix(docs): add missing blank line before list in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ All charts are published to GHCR with cosign signatures for verification.
 Deploy Cloudflare Tunnel (cloudflared) for secure Zero Trust access to Kubernetes services without exposing inbound ports.
 
 **Key Features:**
+
 - Zero Trust network access with Cloudflare's edge
 - Dual deployment modes (Deployment/DaemonSet)
 - Prometheus metrics and high availability support


### PR DESCRIPTION
## Summary

Fix markdown linting error in root README.md.

### Fixed

- Add missing blank line after `**Key Features:**` header before list
- Fixes markdownlint error MD032: Lists should be surrounded by blank lines

### Details

The cloudflare-tunnel section was missing a blank line between the "Key Features:" header and the bullet list, causing markdown linting to fail.

## Test plan

- [x] Run `markdownlint README.md` - passes without errors

Co-Authored-By: Claude <noreply@anthropic.com>