### PR TITLE
feat: add kubeVersion constraints to all charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ All charts are published to GHCR with cosign signatures for verification.
 
 ### [cloudflare-tunnel](./charts/cloudflare-tunnel)
 
-![Version](https://img.shields.io/badge/version-0.12.5-informational)
+![Version](https://img.shields.io/badge/version-0.12.6-informational)
+![Kubernetes](https://img.shields.io/badge/Kubernetes-1.21%2B-blue?logo=kubernetes)
 
 Deploy Cloudflare Tunnel (cloudflared) for secure Zero Trust access to Kubernetes services without exposing inbound ports.
 
@@ -28,7 +29,8 @@ Deploy Cloudflare Tunnel (cloudflared) for secure Zero Trust access to Kubernete
 
 ### [me-site](./charts/me-site)
 
-![Version](https://img.shields.io/badge/version-0.4.2-informational)
+![Version](https://img.shields.io/badge/version-0.4.3-informational)
+![Kubernetes](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)
 
 Personal site deployment with HTTPRoute/Gateway API support.
 
@@ -36,7 +38,8 @@ Personal site deployment with HTTPRoute/Gateway API support.
 
 ### [system-upgrade-controller](./charts/system-upgrade-controller)
 
-![Version](https://img.shields.io/badge/version-0.1.4-informational)
+![Version](https://img.shields.io/badge/version-0.1.5-informational)
+![Kubernetes](https://img.shields.io/badge/Kubernetes-1.16%2B-blue?logo=kubernetes)
 
 Kubernetes-native controller for automated node upgrades using declarative Plans. Based on [Rancher System Upgrade Controller](https://github.com/rancher/system-upgrade-controller).
 
@@ -51,7 +54,8 @@ Kubernetes-native controller for automated node upgrades using declarative Plans
 
 ### [transmission](./charts/transmission)
 
-![Version](https://img.shields.io/badge/version-0.1.6-informational)
+![Version](https://img.shields.io/badge/version-0.1.7-informational)
+![Kubernetes](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)
 
 Transmission BitTorrent client deployment with NFS and PVC storage support.
 
@@ -59,7 +63,8 @@ Transmission BitTorrent client deployment with NFS and PVC storage support.
 
 ### [vipalived](./charts/vipalived)
 
-![Version](https://img.shields.io/badge/version-0.3.1-informational)
+![Version](https://img.shields.io/badge/version-0.3.2-informational)
+![Kubernetes](https://img.shields.io/badge/Kubernetes-1.16%2B-blue?logo=kubernetes)
 
 VRRP-based Virtual IP management for Kubernetes control plane high availability using keepalived.
 
@@ -82,28 +87,28 @@ All charts are published to GitHub Container Registry as OCI artifacts.
 # Install cloudflare-tunnel chart
 helm install my-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.12.5 \
+  --version 0.12.6 \
   --values values.yaml
 
 # Install system-upgrade-controller
 helm install system-upgrade-controller \
   oci://ghcr.io/lexfrei/charts/system-upgrade-controller \
-  --version 0.1.4
+  --version 0.1.5
 
 # Install transmission
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 0.1.6
+  --version 0.1.7
 
 # Install me-site
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.4.2
+  --version 0.4.3
 
 # Install vipalived
 helm install vipalived \
   oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR
 ```
 

--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -4,11 +4,9 @@ annotations:
   # See: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |-
     - kind: added
-      description: Add Rancher questions.yaml for interactive UI configuration
-    - kind: added
-      description: Add Artifact Hub badge and consistency badges to README
+      description: Add kubeVersion constraint (>=1.21.0-0) to Chart.yaml
     - kind: changed
-      description: Improve README structure with better badge organization
+      description: Update Kubernetes version badge to reflect actual minimum version (1.21+)
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -22,7 +20,8 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Creation of a cloudflared deployment - a reverse tunnel for an environment
 type: application
-version: "0.12.5"
+version: "0.12.6"
+kubeVersion: ">=1.21.0-0"
 # renovate: datasource=github-releases depName=cloudflare/cloudflared
 appVersion: "2025.10.1"
 icon: https://avatars.githubusercontent.com/u/314135

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.12.5](https://img.shields.io/badge/Version-0.12.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.10.1](https://img.shields.io/badge/AppVersion-2025.10.1-informational?style=flat-square)
+![Version: 0.12.6](https://img.shields.io/badge/Version-0.12.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.10.1](https://img.shields.io/badge/AppVersion-2025.10.1-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -8,7 +8,7 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudflare-tunnel)](https://artifacthub.io/packages/helm/cloudflare-tunnel/cloudflare-tunnel)
 [![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
 [![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
-[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.21%2B-blue?logo=kubernetes)](https://kubernetes.io/)
 
 Creation of a cloudflared deployment - a reverse tunnel for an environment
 
@@ -69,7 +69,7 @@ Before installing the chart, create a tunnel in Cloudflare:
 # Install with inline configuration
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.12.5 \
+  --version 0.12.6 \
   --set cloudflare.account=YOUR_ACCOUNT_ID \
   --set cloudflare.tunnelName=YOUR_TUNNEL_NAME \
   --set cloudflare.tunnelId=YOUR_TUNNEL_ID \
@@ -80,7 +80,7 @@ helm install cloudflare-tunnel \
 # Install with values file
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.12.5 \
+  --version 0.12.6 \
   --values values.yaml
 ```
 
@@ -90,7 +90,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.12.5 \
+  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.12.6 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -457,6 +457,10 @@ If experiencing port exhaustion on nodes:
 * <https://github.com/lexfrei/charts/>
 * <https://github.com/cloudflare/cloudflared/>
 <!-- markdownlint-enable MD004 -->
+
+## Requirements
+
+Kubernetes: `>=1.21.0-0`
 
 ## Values
 

--- a/charts/cloudflare-tunnel/README.md.gotmpl
+++ b/charts/cloudflare-tunnel/README.md.gotmpl
@@ -10,7 +10,7 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cloudflare-tunnel)](https://artifacthub.io/packages/helm/cloudflare-tunnel/cloudflare-tunnel)
 [![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
 [![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
-[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.21%2B-blue?logo=kubernetes)](https://kubernetes.io/)
 
 {{ template "chart.description" . }}
 

--- a/charts/me-site/Chart.yaml
+++ b/charts/me-site/Chart.yaml
@@ -2,17 +2,16 @@ apiVersion: v2
 name: me-site
 description: A Helm chart for the Me-Site application
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: 1.0.0
-
 maintainers:
   - name: lexfrei
     email: f@lex.la
     url: https://github.com/lexfrei
-
 annotations:
-  artifacthub.io/changes: |
+  artifacthub.io/changes: |-
     - kind: added
-      description: Add Rancher questions.yaml for interactive UI configuration
+      description: Add kubeVersion constraint (>=1.19.0-0) to Chart.yaml
     - kind: changed
-      description: Improve README structure with consistency badges
+      description: Update Kubernetes version badge to reflect actual minimum version (1.19+)
+kubeVersion: '>=1.19.0-0'

--- a/charts/me-site/README.md
+++ b/charts/me-site/README.md
@@ -1,10 +1,13 @@
 # me-site
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
 [![Lint and Test](https://github.com/lexfrei/charts/actions/workflows/test.yaml/badge.svg)](https://github.com/lexfrei/charts/actions/workflows/test.yaml)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
+[![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
 
 A Helm chart for the Me-Site application
 
@@ -14,6 +17,10 @@ A Helm chart for the Me-Site application
 | ---- | ------ | --- |
 | lexfrei | <f@lex.la> | <https://github.com/lexfrei> |
 
+## Requirements
+
+Kubernetes: `>=1.19.0-0`
+
 ## Installing the Chart
 
 This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
@@ -22,12 +29,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.4.2
+  --version 0.4.3
 
 # Install with custom values
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.4.2 \
+  --version 0.4.3 \
   --values values.yaml
 ```
 
@@ -37,7 +44,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/me-site:0.4.2 \
+  ghcr.io/lexfrei/charts/me-site:0.4.3 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/me-site/README.md.gotmpl
+++ b/charts/me-site/README.md.gotmpl
@@ -7,6 +7,9 @@
 ## 📊 Status & Metrics
 
 [![Lint and Test](https://github.com/lexfrei/charts/actions/workflows/test.yaml/badge.svg)](https://github.com/lexfrei/charts/actions/workflows/test.yaml)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
+[![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
 
 {{ template "chart.description" . }}
 

--- a/charts/system-upgrade-controller/Chart.yaml
+++ b/charts/system-upgrade-controller/Chart.yaml
@@ -2,11 +2,9 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/changes: |-
     - kind: added
-      description: Add Rancher questions.yaml for interactive UI configuration
-    - kind: added
-      description: Add Artifact Hub badge and consistency badges to README
+      description: Add kubeVersion constraint (>=1.16.0-0) to Chart.yaml
     - kind: changed
-      description: Improve README structure with better badge organization
+      description: Update Kubernetes version badge to reflect actual minimum version (1.16+)
   artifacthub.io/crds: |
     - kind: Plan
       version: v1
@@ -26,7 +24,7 @@ apiVersion: v2
 name: system-upgrade-controller
 description: Kubernetes-native upgrade controller for nodes using declarative Plans
 type: application
-version: "0.1.4"
+version: "0.1.5"
 # renovate: datasource=github-releases depName=rancher/system-upgrade-controller
 appVersion: "v0.17.0"
 icon: https://avatars.githubusercontent.com/u/9343010
@@ -49,3 +47,4 @@ maintainers:
 sources:
   - https://github.com/lexfrei/charts/
   - https://github.com/rancher/system-upgrade-controller/
+kubeVersion: '>=1.16.0-0'

--- a/charts/system-upgrade-controller/README.md
+++ b/charts/system-upgrade-controller/README.md
@@ -1,6 +1,6 @@
 # system-upgrade-controller
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.0](https://img.shields.io/badge/AppVersion-v0.17.0-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.0](https://img.shields.io/badge/AppVersion-v0.17.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -8,7 +8,7 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/system-upgrade)](https://artifacthub.io/packages/helm/system-upgrade/system-upgrade-controller)
 [![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
 [![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
-[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.16%2B-blue?logo=kubernetes)](https://kubernetes.io/)
 
 Kubernetes-native upgrade controller for nodes using declarative Plans
 
@@ -24,6 +24,10 @@ Kubernetes-native upgrade controller for nodes using declarative Plans
 
 * <https://github.com/lexfrei/charts/>
 * <https://github.com/rancher/system-upgrade-controller/>
+
+## Requirements
+
+Kubernetes: `>=1.16.0-0`
 
 ## Introduction
 

--- a/charts/system-upgrade-controller/README.md.gotmpl
+++ b/charts/system-upgrade-controller/README.md.gotmpl
@@ -10,7 +10,7 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/system-upgrade)](https://artifacthub.io/packages/helm/system-upgrade/system-upgrade-controller)
 [![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
 [![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
-[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.16%2B-blue?logo=kubernetes)](https://kubernetes.io/)
 
 {{ template "chart.description" . }}
 

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,11 +2,9 @@ annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
     - kind: added
-      description: Add Rancher questions.yaml for interactive UI configuration
-    - kind: added
-      description: Add Artifact Hub badge and consistency badges to README
+      description: Add kubeVersion constraint (>=1.19.0-0) to Chart.yaml
     - kind: changed
-      description: Improve README structure with better badge organization
+      description: Update Kubernetes version badge to reflect actual minimum version (1.19+)
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -20,7 +18,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "0.1.6"
+version: "0.1.7"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.0.6"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png
@@ -41,3 +39,4 @@ sources:
   - https://github.com/lexfrei/charts/
   - https://github.com/transmission/transmission
   - https://github.com/linuxserver/docker-transmission
+kubeVersion: '>=1.19.0-0'

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -26,6 +26,10 @@ Transmission BitTorrent client Helm chart for Kubernetes
 * <https://github.com/transmission/transmission>
 * <https://github.com/linuxserver/docker-transmission>
 
+## Requirements
+
+Kubernetes: `>=1.19.0-0`
+
 ## Installing the Chart
 
 This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
@@ -34,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 0.1.6
+  --version 0.1.7
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 0.1.6 \
+  --version 0.1.7 \
   --values values.yaml
 ```
 
@@ -49,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:0.1.6 \
+  ghcr.io/lexfrei/charts/transmission:0.1.7 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -2,11 +2,9 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
     - kind: added
-      description: Add Rancher questions.yaml for interactive UI configuration
-    - kind: added
-      description: Add Artifact Hub badge and consistency badges to README
+      description: Add kubeVersion constraint (>=1.16.0-0) to Chart.yaml
     - kind: changed
-      description: Improve README structure with better badge organization
+      description: Update Kubernetes version badge to reflect actual minimum version (1.16+)
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -20,7 +18,7 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.3.1
+version: 0.3.2
 # renovate: datasource=docker depName=alpine
 appVersion: "3.22"
 keywords:
@@ -33,3 +31,4 @@ keywords:
 maintainers:
   - name: lexfrei
     email: f@lex.la
+kubeVersion: '>=1.16.0-0'

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -1,6 +1,6 @@
 # vipalived
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.22](https://img.shields.io/badge/AppVersion-3.22-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.22](https://img.shields.io/badge/AppVersion-3.22-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -8,7 +8,7 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/vipalived)](https://artifacthub.io/packages/helm/vipalived/vipalived)
 [![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
 [![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
-[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.16%2B-blue?logo=kubernetes)](https://kubernetes.io/)
 
 Keepalived-based VIP management for Kubernetes control plane high availability
 
@@ -16,16 +16,16 @@ Keepalived-based VIP management for Kubernetes control plane high availability
 
 ```bash
 # Day 2: Install with default VIP (172.16.101.101/32) on existing cluster
-helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.3.1
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.3.2
 
 # Day 2: Install with custom VIP address
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
 
 # Day 1: Generate static pod manifest for cluster bootstrap
 helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.3.1 \
+  --version 0.3.2 \
   --set static=true \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
 ```
@@ -75,7 +75,7 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 
    ```bash
    helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-     --version 0.3.1 \
+     --version 0.3.2 \
      --set static=true \
      --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR \
      --namespace kube-system > vipalived-static-pod.yaml
@@ -138,7 +138,7 @@ All charts published to GHCR are signed using cosign. To verify the chart signat
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/vipalived:0.3.1 \
+  ghcr.io/lexfrei/charts/vipalived:0.3.2 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/vipalived/README.md.gotmpl
+++ b/charts/vipalived/README.md.gotmpl
@@ -8,7 +8,7 @@
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/vipalived)](https://artifacthub.io/packages/helm/vipalived/vipalived)
 [![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
 [![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
-[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.16%2B-blue?logo=kubernetes)](https://kubernetes.io/)
 
 {{ template "chart.description" . }}
 


### PR DESCRIPTION
## Summary

Add explicit Kubernetes version requirements to `Chart.yaml` for all charts based on the minimum API versions they use.

## Changes

### Chart Versions
- **cloudflare-tunnel**: 0.12.5 → 0.12.6, kubeVersion: `>=1.21.0-0`
  - Requires Kubernetes 1.21+ for `policy/v1` (PodDisruptionBudget)
- **me-site**: 0.4.2 → 0.4.3, kubeVersion: `>=1.19.0-0`
  - Requires Kubernetes 1.19+ for `networking.k8s.io/v1` (Ingress)
  - Note: Gateway API and VPA are external CRDs, not Kubernetes core
- **system-upgrade-controller**: 0.1.4 → 0.1.5, kubeVersion: `>=1.16.0-0`
  - Requires Kubernetes 1.16+ for `apiextensions.k8s.io/v1` (CRDs)
- **transmission**: 0.1.6 → 0.1.7, kubeVersion: `>=1.19.0-0`
  - Requires Kubernetes 1.19+ for `networking.k8s.io/v1` (Ingress)
- **vipalived**: 0.3.1 → 0.3.2, kubeVersion: `>=1.16.0-0`
  - Baseline Kubernetes version

### Documentation
- Updated Kubernetes version badges in all `README.md.gotmpl` templates
- Updated root `README.md` with correct Kubernetes requirements and latest chart versions
- Regenerated all `README.md` files with helm-docs

## Why?

The `kubeVersion` constraint in `Chart.yaml` allows Helm to validate that the target cluster meets minimum Kubernetes API requirements before attempting installation. This prevents deployment failures on incompatible clusters.

## Testing

- [x] All Chart.yaml files have valid kubeVersion constraints
- [x] All README badges reflect correct Kubernetes versions
- [x] READMEs regenerated with helm-docs
- [ ] CI tests pass

## Related

Fixes the issue where charts showed generic "1.19+" badge without actual validation of minimum Kubernetes requirements.