### PR TITLE
fix(ci): use repository_dispatch to create commit statuses for renovate PRs

### DIFF
--- a/.github/workflows/renovate-update.yaml
+++ b/.github/workflows/renovate-update.yaml
@@ -125,24 +125,20 @@ jobs:
       - name: Trigger tests after bot commit
         if: steps.update.outputs.changes_made == 'true'
         run: |
-          # Get list of changed charts from the update step
-          changed_charts=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | \
-            grep -E '^charts/.+/(Chart\.yaml|values\.yaml)$' | \
-            sed 's|/[^/]*$||' | \
-            sort -u | \
-            jq -R -s -c 'split("\n") | map(select(length > 0))')
+          # Get the commit SHA we just pushed
+          COMMIT_SHA=$(git rev-parse HEAD)
 
-          echo "Triggering tests for charts: $changed_charts"
+          echo "Triggering tests via repository_dispatch for commit $COMMIT_SHA"
 
-          # Only trigger if we have charts to test
-          if [[ "$changed_charts" != "[]" ]]; then
-            # Trigger the test workflow with the changed charts
-            gh workflow run test.yaml \
-              --ref ${{ github.head_ref }} \
-              --field charts="$changed_charts"
-            echo "✅ Test workflow triggered successfully"
-          else
-            echo "ℹ️ No charts to test, skipping workflow trigger"
-          fi
+          # Trigger the test workflow via repository_dispatch
+          # This will create commit statuses that are visible in the PR
+          gh api repos/${{ github.repository }}/dispatches \
+            --method POST \
+            --field event_type=test-charts \
+            --field "client_payload[sha]=$COMMIT_SHA" \
+            --field "client_payload[ref]=${{ github.head_ref }}" \
+            --field "client_payload[pr_number]=${{ github.event.pull_request.number }}"
+
+          echo "✅ Test workflow triggered successfully via repository_dispatch"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,10 +13,49 @@ on:
         description: 'JSON array of chart paths to test (optional)'
         required: false
         type: string
+  repository_dispatch:
+    types:
+      - test-charts
 
 jobs:
+  create-pending-statuses:
+    # Only run for repository_dispatch events to create commit statuses
+    if: github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    strategy:
+      matrix:
+        chart:
+          - charts/cloudflare-tunnel
+          - charts/me-site
+          - charts/system-upgrade-controller
+          - charts/transmission
+          - charts/vipalived
+    steps:
+      - name: Create pending status
+        run: |
+          CONTEXT="lint-test (${{ matrix.chart }})"
+          SHA="${{ github.event.client_payload.sha }}"
+
+          echo "Creating pending status for $CONTEXT on commit $SHA"
+
+          gh api repos/${{ github.repository }}/statuses/$SHA \
+            --method POST \
+            --field state=pending \
+            --field context="$CONTEXT" \
+            --field description="Running tests..." \
+            --field target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   lint-test:
     runs-on: ubuntu-latest
+    needs: [create-pending-statuses]
+    if: always() && (needs.create-pending-statuses.result == 'success' || needs.create-pending-statuses.result == 'skipped')
+    permissions:
+      contents: read
+      statuses: write
     strategy:
       matrix:
         chart:
@@ -144,3 +183,37 @@ jobs:
           else
             echo "ℹ️  No README.md found, skipping"
           fi
+
+      - name: Update commit status on success
+        if: success() && github.event_name == 'repository_dispatch'
+        run: |
+          CONTEXT="lint-test (${{ matrix.chart }})"
+          SHA="${{ github.event.client_payload.sha }}"
+
+          echo "✅ Updating status for $CONTEXT on commit $SHA to success"
+
+          gh api repos/${{ github.repository }}/statuses/$SHA \
+            --method POST \
+            --field state=success \
+            --field context="$CONTEXT" \
+            --field description="All checks passed" \
+            --field target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update commit status on failure
+        if: failure() && github.event_name == 'repository_dispatch'
+        run: |
+          CONTEXT="lint-test (${{ matrix.chart }})"
+          SHA="${{ github.event.client_payload.sha }}"
+
+          echo "❌ Updating status for $CONTEXT on commit $SHA to failure"
+
+          gh api repos/${{ github.repository }}/statuses/$SHA \
+            --method POST \
+            --field state=failure \
+            --field context="$CONTEXT" \
+            --field description="Some checks failed" \
+            --field target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

Renovate PRs were stuck in "Waiting for status to be reported" state because:

1. Renovate creates PR → `pull_request` event triggers tests ✅
2. `renovate-update.yaml` commits changes (changelog, docs) using `GITHUB_TOKEN`
3. GitHub **doesn't trigger** `pull_request` event for commits made with `GITHUB_TOKEN` (prevents recursive workflows)
4. `renovate-update.yaml` manually triggers tests via `workflow_dispatch`
5. But `workflow_dispatch` runs **don't create commit statuses** for PRs
6. PR waits indefinitely for required status checks 🔴

## Solution

Use `repository_dispatch` event to trigger tests and create commit statuses manually via GitHub API:

1. `renovate-update.yaml` sends `repository_dispatch` event with commit SHA
2. `test.yaml` creates "pending" commit statuses for all charts
3. Tests run for each chart
4. After each test completes, update status to "success" or "failure"
5. These statuses are visible in PR and allow auto-merge to work ✅

## Changes

### `.github/workflows/test.yaml`
- ➕ Added `repository_dispatch` trigger with type `test-charts`
- ➕ New job `create-pending-statuses` creates pending statuses before tests
- ➕ Added steps in `lint-test` to update statuses after completion
- ➕ Added permissions `statuses: write` for status creation

### `.github/workflows/renovate-update.yaml`
- 🔄 Replaced `gh workflow run` with `gh api .../dispatches` (repository_dispatch)
- 🔄 Pass commit SHA in `client_payload` for status creation

## Testing

After merging this PR, the next Renovate PR should:
1. Receive automatic commit from github-actions[bot] with changelog/docs
2. Automatically get commit statuses via repository_dispatch
3. Statuses will be visible in PR
4. Auto-merge will work when all statuses are green

## Related Issues

Fixes #109 (indirectly - solves the root cause)