### PR TITLE
fix(renovate): use matchDepNames for proper dependency grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,13 +10,18 @@
   "ignoreTests": false,
   "packageRules": [
     {
-      "description": "Group same dependencies across Chart.yaml and tests",
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "groupName": "{{depName}}",
-      "groupSlug": "{{depName}}",
-      "commitMessageTopic": "dependency {{depName}}"
+      "description": "Group cloudflare/cloudflared updates across Chart.yaml and tests",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["cloudflare/cloudflared"],
+      "groupName": "cloudflare/cloudflared",
+      "commitMessageTopic": "dependency cloudflare/cloudflared"
+    },
+    {
+      "description": "Group linuxserver/transmission updates across Chart.yaml and tests",
+      "matchDatasources": ["docker"],
+      "matchDepNames": ["linuxserver/transmission"],
+      "groupName": "linuxserver/transmission",
+      "commitMessageTopic": "dependency linuxserver/transmission"
     },
     {
       "description": "Auto-bump chart version when appVersion changes",
@@ -42,8 +47,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Chart\\.yaml$/"
+      "fileMatch": [
+        "(^|/)Chart\\.yaml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?appVersion: \"(?<currentValue>.*?)\""


### PR DESCRIPTION
## Problem

Renovate creates **separate PRs** for the same dependency update instead of grouping them:
- PR #114/#117: Updates only `Chart.yaml` 
- Missing: Updates to `tests/deployment_test.yaml`

This causes test failures because versions desynchronize.

## Root Cause

Current configuration tried to group via `matchManagers: ["custom.regex"]` with template `groupName: "{{depName}}"`. This doesn't work because:
- Template only applies **within** a single discovered dependency
- Doesn't **link** separate discoveries of the same dependency across different files

## Solution

Use **explicit grouping** via `matchDepNames`:

```json
{
  "matchDatasources": ["docker"],
  "matchDepNames": ["cloudflare/cloudflared"],
  "groupName": "cloudflare/cloudflared"
}
```

## Changes

1. **Replaced broken grouping rule** with explicit rules for:
   - `cloudflare/cloudflared`
   - `linuxserver/transmission`

2. **Fixed `fileMatch` syntax** in first customManager:
   - `managerFilePatterns` → `fileMatch` (correct field name)

## Expected Behavior After Merge

When Renovate detects new version of `cloudflare/cloudflared`:
- ✅ Creates **ONE PR** updating both:
  - `charts/cloudflare-tunnel/Chart.yaml` appVersion
  - `charts/cloudflare-tunnel/tests/deployment_test.yaml` image version
- ✅ Tests pass (versions synchronized)
- ✅ Auto-merge works correctly

## Testing

- ✅ JSON syntax validated with `jq`
- ✅ Configuration follows Renovate schema
- After merge: close PR #114/#117 and wait for Renovate to create new grouped PR