### PR TITLE
fix(renovate): use managerFilePatterns for regex customManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,8 +47,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "(^|/)Chart\\.yaml$"
+      "managerFilePatterns": [
+        "/(^|/)Chart\\.yaml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?appVersion: \"(?<currentValue>.*?)\""
@@ -59,11 +59,11 @@
     {
       "customType": "regex",
       "description": "Update container image versions in Helm unit tests",
-      "fileMatch": [
-        "^charts/.+/tests/.+\\.yaml$"
+      "managerFilePatterns": [
+        "/^charts\\/.+\\/tests\\/.+\\.yaml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?value: [\"'][^:]+:(?<currentValue>.*?)[\"']"
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{depName}}"


### PR DESCRIPTION
## Critical Fix

Regex customManagers require **`managerFilePatterns`**, not `fileMatch`.

## Problem

PR #118 incorrectly changed `managerFilePatterns` → `fileMatch`, thinking it was fixing syntax. This caused Renovate to NOT detect dependencies in test files.

**Evidence**: Dependency Dashboard shows `cloudflare/cloudflared` only in `Chart.yaml`, NOT in `tests/deployment_test.yaml`.

## Root Cause

Per [Renovate docs](https://docs.renovatebot.com/modules/manager/regex/):
- **`managerFilePatterns`**: Required for regex customManagers  
- **`fileMatch`**: Used by other manager types

## Changes

1. **Restore `managerFilePatterns`** in both customManagers
2. **Add slashes** around regex (required syntax: `"/pattern/"`)  
3. **Improve test regex**: Use `\\s+` instead of `\\n` for whitespace matching

## Expected After Merge

Renovate will detect `cloudflare/cloudflared` in:
- ✅ `charts/cloudflare-tunnel/Chart.yaml`  
- ✅ `charts/cloudflare-tunnel/tests/deployment_test.yaml`

And create grouped PRs updating **both** files together.