### PR TITLE
fix(renovate): remove double escaping in managerFilePatterns

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,7 +60,7 @@
       "customType": "regex",
       "description": "Update container image versions in Helm unit tests",
       "managerFilePatterns": [
-        "/^charts\\/.+\\/tests\\/.+\\.yaml$/"
+        "/^charts/.+/tests/.+\\.yaml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"


### PR DESCRIPTION
## Fix

Removed double escaping of slashes in `managerFilePatterns`.

## Problem

Pattern had: `"/^charts\\/.+\\/tests\\/.+\\.yaml$/"`

But slashes in JSON strings don't need escaping.

## Solution

Changed to: `"/^charts/.+/tests/.+\\.yaml$/"`

## Local Testing

```python
✅ Path matches: charts/cloudflare-tunnel/tests/deployment_test.yaml
✅ Regex matches content!
   datasource: docker
   depName: cloudflare/cloudflared
   currentValue: 2025.10.1
```

This should allow Renovate to detect dependencies in test files.