### PR TITLE
fix(renovate): use fileMatch for regex customManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,8 +47,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Chart\\.yaml$/"
+      "fileMatch": [
+        "(^|/)Chart\\.yaml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?appVersion: \"(?<currentValue>.*?)\""
@@ -59,11 +59,11 @@
     {
       "customType": "regex",
       "description": "Update container image versions in Helm unit tests",
-      "managerFilePatterns": [
-        "/^charts/.+/tests/.+\\.yaml$/"
+      "fileMatch": [
+        "^charts/.+/tests/.+\\.yaml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{depName}}"


### PR DESCRIPTION
## Critical Fix

Regex customManagers should use **`fileMatch`**, not `managerFilePatterns`.

## Evidence

Working examples from 2024 ([source](https://seankilleen.com/2024/12/how-to-get-package-updates-in-hard-to-reach-places-with-renovatebot/)):
```json
{
  "customType": "regex",
  "fileMatch": ["^Dockerfile$"],
  "matchStrings": ["..."]
}
```

NOT:
```json
{
  "customType": "regex",
  "managerFilePatterns": ["/^Dockerfile$/"]
}
```

## Changes

1. **`managerFilePatterns` → `fileMatch`** in both customManagers
2. **Remove slashes** around patterns (fileMatch doesn't use `/pattern/` syntax)
3. **`\\s+` → `\\n.*?`** for better multiline matching (per working examples)

## Local Testing

```
✅ fileMatch matches: charts/cloudflare-tunnel/tests/deployment_test.yaml  
✅ matchStrings extracts: datasource=docker, depName=cloudflare/cloudflared, currentValue=2025.10.1
```

This should finally allow Renovate to detect dependencies in test files.