### PR TITLE
fix(renovate): use renovatebot's official approach for customManagers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,11 +59,11 @@
     {
       "customType": "regex",
       "description": "Update container image versions in Helm unit tests",
-      "fileMatch": [
-        "^charts/.+/tests/.+\\.yaml$"
+      "managerFilePatterns": [
+        "/^charts\\/.+\\/tests\\/.+\\.yaml$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n +value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{depName}}"


### PR DESCRIPTION
## Solution Based on Official renovatebot/helm-charts

Found the official renovatebot Helm charts repository config:
https://github.com/renovatebot/helm-charts/blob/main/renovate.json

## Key Differences from My Previous Attempts

1. **Use `managerFilePatterns`** (not `fileMatch`) with slashes:
   ```json
   "managerFilePatterns": ["/^charts\\/.+\\/tests\\/.+\\.yaml$/"]
   ```

2. **Use literal spaces** ` +` instead of `\\s+`:
   ```json
   "\\n +value:"  // NOT "\\n\\s+value:"
   ```

3. **Use `\\S+` for non-whitespace matching**:
   ```json
   "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)"
   ```

## Changes

```json
{
  "managerFilePatterns": ["/^charts\\/.+\\/tests\\/.+\\.yaml$/"],
  "matchStrings": [
    "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n +value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
  ]
}
```

## Local Testing

```
✅ Pattern matches: charts/cloudflare-tunnel/tests/deployment_test.yaml
✅ Extracts: datasource=docker, depName=cloudflare/cloudflared, currentValue=2025.10.1
```

This should finally work as it follows renovatebot's official pattern.