### PR TITLE
fix(renovate): use fileMatch instead of managerFilePatterns for test files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,8 +59,8 @@
     {
       "customType": "regex",
       "description": "Update container image versions in Helm unit tests",
-      "managerFilePatterns": [
-        "/^charts\\/.+\\/tests\\/.+\\.yaml$/"
+      "fileMatch": [
+        "charts/.+/tests/.+\\.yaml$"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n +value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"


### PR DESCRIPTION
## Summary

Change the customManager for test files to use `fileMatch` instead of `managerFilePatterns` to align with the first customManager configuration that successfully detects Chart.yaml files.

## Changes

- Changed `managerFilePatterns` to `fileMatch` in the test files customManager
- Simplified regex pattern from `/^charts\\/.+\\/tests\\/.+\\.yaml$/` to `charts/.+/tests/.+\\.yaml$`

## Rationale

The first customManager (for Chart.yaml) uses `fileMatch` and works correctly. The second customManager (for test files) was using `managerFilePatterns` with different syntax, which Renovate was not detecting. By aligning both to use `fileMatch`, we should achieve consistent behavior.

## Testing

After merging, will set checkbox in Dependency Dashboard to trigger Renovate run and verify that both Chart.yaml and test files are detected and grouped together.