### PR TITLE
fix(renovate): add whitespace handling in test files regex pattern

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,7 +63,7 @@
         "charts/.+/tests/.+\\.yaml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n +value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
+        "\\s*# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s*value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{depName}}"


### PR DESCRIPTION
## Summary

Fix the regex pattern in customManagers to properly handle leading whitespace in YAML test files.

## Problem

The previous regex pattern didn't account for indentation in YAML test files:
```yaml
          # renovate: datasource=docker depName=cloudflare/cloudflared
          value: "cloudflare/cloudflared:2025.10.1"
```

## Changes

- Added `\s*` before `#` to match optional leading whitespace
- Changed ` +` to `\s*` before `value:` for more flexible whitespace matching

## Previous Pattern
```
"# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n +value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
```

## New Pattern
```
"\\s*# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s*value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
```

## Testing

After merging, will close PR #130 and set checkbox in Dependency Dashboard to verify that both Chart.yaml and test files are now detected and updated together.