### PR TITLE
fix(transmission): remove environment-specific default ingress annotations

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -23,3 +23,8 @@ MD033:
 
 # MD041/first-line-heading - First line in file should be a top level heading
 MD041: false
+
+# MD060/table-column-style - Table column style
+# Set to consistent to allow helm-docs generated tables
+MD060:
+  style: "consistent"

--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -3,8 +3,10 @@ annotations:
   # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
   # See: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update dependency cloudflare/cloudflared to v2025.11.0
+    - kind: added
+      description: "Add schema validation for annotations (must be string values)"
+    - kind: added
+      description: "Add unit test for default annotations"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -18,7 +20,7 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Creation of a cloudflared deployment - a reverse tunnel for an environment
 type: application
-version: "0.13.0"
+version: "0.13.1"
 kubeVersion: ">=1.21.0-0"
 # renovate: datasource=docker depName=cloudflare/cloudflared
 appVersion: "2025.10.1"

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.10.1](https://img.shields.io/badge/AppVersion-2025.10.1-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.10.1](https://img.shields.io/badge/AppVersion-2025.10.1-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -69,7 +69,7 @@ Before installing the chart, create a tunnel in Cloudflare:
 # Install with inline configuration
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.13.0 \
+  --version 0.13.1 \
   --set cloudflare.account=YOUR_ACCOUNT_ID \
   --set cloudflare.tunnelName=YOUR_TUNNEL_NAME \
   --set cloudflare.tunnelId=YOUR_TUNNEL_ID \
@@ -80,7 +80,7 @@ helm install cloudflare-tunnel \
 # Install with values file
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.13.0 \
+  --version 0.13.1 \
   --values values.yaml
 ```
 
@@ -90,7 +90,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.13.0 \
+  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.13.1 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/cloudflare-tunnel/tests/serviceaccount_test.yaml
+++ b/charts/cloudflare-tunnel/tests/serviceaccount_test.yaml
@@ -16,6 +16,17 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-cloudflare-tunnel
 
+  - it: should have no annotations by default
+    set:
+      cloudflare:
+        account: "test-account"
+        tunnelName: "test-tunnel"
+        tunnelId: "test-id"
+        secret: "test-secret"
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
   - it: should add annotations when specified
     set:
       cloudflare:

--- a/charts/cloudflare-tunnel/values.schema.json
+++ b/charts/cloudflare-tunnel/values.schema.json
@@ -165,7 +165,11 @@
       "type": "object",
       "properties": {
         "annotations": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the service account (must be string key-value pairs)"
         },
         "name": {
           "type": [
@@ -177,7 +181,11 @@
       }
     },
     "podAnnotations": {
-      "type": "object"
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Pod annotations (must be string key-value pairs)"
     },
     "podSecurityContext": {
       "type": "object",

--- a/charts/me-site/Chart.yaml
+++ b/charts/me-site/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: me-site
 description: A Helm chart for the Me-Site application
 type: application
-version: 0.5.0
+version: 0.5.1
 appVersion: 1.0.0
 maintainers:
   - name: lexfrei
@@ -11,11 +11,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: added
-      description: Add NOTES.txt with post-installation instructions
+      description: "Add schema validation for annotations (must be string values)"
     - kind: added
-      description: Add NetworkPolicy template for network isolation
-    - kind: security
-      description: Add podSecurityContext and seccompProfile RuntimeDefault
-    - kind: changed
-      description: Migrate securityContext from hardcoded to configurable values
+      description: "Add unit test for default annotations"
 kubeVersion: '>=1.19.0-0'

--- a/charts/me-site/README.md
+++ b/charts/me-site/README.md
@@ -1,6 +1,6 @@
 # me-site
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -29,12 +29,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.5.0
+  --version 0.5.1
 
 # Install with custom values
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.5.0 \
+  --version 0.5.1 \
   --values values.yaml
 ```
 
@@ -44,7 +44,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/me-site:0.5.0 \
+  ghcr.io/lexfrei/charts/me-site:0.5.1 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/me-site/templates/ingress.yaml
+++ b/charts/me-site/templates/ingress.yaml
@@ -3,8 +3,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: me-site
+  {{- with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/me-site/tests/ingress_test.yaml
+++ b/charts/me-site/tests/ingress_test.yaml
@@ -48,7 +48,14 @@ tests:
           value: traefik
 
   # Annotations tests
-  - it: should set annotations
+  - it: should have no annotations by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: should set annotations when provided
     set:
       ingress.enabled: true
       ingress.annotations:

--- a/charts/me-site/values.schema.json
+++ b/charts/me-site/values.schema.json
@@ -102,7 +102,11 @@
           "type": "string"
         },
         "annotations": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Ingress annotations (must be string key-value pairs)"
         },
         "hosts": {
           "type": "array",
@@ -156,7 +160,11 @@
           "type": "boolean"
         },
         "annotations": {
-          "type": "object"
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "HTTPRoute annotations (must be string key-value pairs)"
         },
         "parentRefs": {
           "type": "array",

--- a/charts/system-upgrade-controller/Chart.yaml
+++ b/charts/system-upgrade-controller/Chart.yaml
@@ -1,8 +1,10 @@
 annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update rancher/kubectl docker tag to v1.34.2
+    - kind: added
+      description: "Add schema validation for annotations (must be string values)"
+    - kind: added
+      description: "Add unit test for default annotations"
   artifacthub.io/crds: |
     - kind: Plan
       version: v1
@@ -22,7 +24,7 @@ apiVersion: v2
 name: system-upgrade-controller
 description: Kubernetes-native upgrade controller for nodes using declarative Plans
 type: application
-version: "0.2.0"
+version: "0.2.1"
 # renovate: datasource=github-releases depName=rancher/system-upgrade-controller
 appVersion: "v0.18.0"
 icon: https://avatars.githubusercontent.com/u/9343010

--- a/charts/system-upgrade-controller/README.md
+++ b/charts/system-upgrade-controller/README.md
@@ -1,6 +1,6 @@
 # system-upgrade-controller
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 

--- a/charts/system-upgrade-controller/tests/serviceaccount_test.yaml
+++ b/charts/system-upgrade-controller/tests/serviceaccount_test.yaml
@@ -45,7 +45,14 @@ tests:
           path: metadata.name
           value: custom-sa
 
-  - it: should include custom annotations
+  - it: should have no annotations by default
+    set:
+      serviceAccount.create: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should include custom annotations when specified
     set:
       serviceAccount.create: true
       serviceAccount.annotations:

--- a/charts/system-upgrade-controller/values.schema.json
+++ b/charts/system-upgrade-controller/values.schema.json
@@ -60,7 +60,10 @@
         },
         "annotations": {
           "type": "object",
-          "description": "Annotations to add to the service account"
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the service account (must be string key-value pairs)"
         },
         "name": {
           "type": "string",
@@ -145,7 +148,10 @@
     },
     "podAnnotations": {
       "type": "object",
-      "description": "Pod annotations"
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Pod annotations (must be string key-value pairs)"
     },
     "podLabels": {
       "type": "object",

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
     - kind: changed
-      description: "existingClaim now takes priority over type for downloads volume, allowing shared storage with other apps"
+      description: "Remove environment-specific default ingress annotations"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +16,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.2.0"
+version: "1.2.1"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.0.6"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,7 +2,11 @@ annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
     - kind: changed
-      description: "Remove environment-specific default ingress annotations"
+      description: "Remove all environment-specific default annotations (ingress, service)"
+    - kind: added
+      description: "Add schema validation for annotations (must be string values)"
+    - kind: added
+      description: "Add unit tests for annotations"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.2.0
+  --version 1.2.1
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.2.0 \
+  --version 1.2.1 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.2.0 \
+  ghcr.io/lexfrei/charts/transmission:1.2.1 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -81,7 +81,7 @@ helm delete transmission
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"linuxserver/transmission","tag":""}` | Image configuration |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` |  |
-| ingress | object | `{"annotations":{"cert-manager.io/cluster-issuer":"cloudflare-issuer","traefik.ingress.kubernetes.io/router.entrypoints":"websecure"},"className":"","enabled":false,"hosts":[{"host":"transmission.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["transmission.example.com"],"secretName":"transmission-tls"}]}` | Ingress configuration |
+| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"transmission.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["transmission.example.com"],"secretName":"transmission-tls"}]}` | Ingress configuration |
 | initContainers | list | [] | Init containers to run before the main container |
 | nameOverride | string | `""` |  |
 | networkPolicy | object | `{"egress":[],"enabled":false,"ingress":[]}` | Network Policy configuration |

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -108,9 +108,9 @@ helm delete transmission
 | podSecurityContext | object | `{"fsGroup":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the pod |
 | resources | object | `{"limits":{"cpu":"400m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource limits and requests |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["SETUID","SETGID","CHOWN"],"drop":["ALL"]},"readOnlyRootFilesystem":false}` | Security context for the container |
-| service | object | `{"torrent":{"annotations":{"metallb.io/address-pool":"transmission-pool"},"enabled":true,"tcpPort":51413,"type":"LoadBalancer","udpPort":51413},"web":{"annotations":{},"port":9091,"type":"ClusterIP"}}` | Service configuration |
-| service.torrent | object | `{"annotations":{"metallb.io/address-pool":"transmission-pool"},"enabled":true,"tcpPort":51413,"type":"LoadBalancer","udpPort":51413}` | Separate LoadBalancer service for torrent ports |
-| service.torrent.annotations | object | `{"metallb.io/address-pool":"transmission-pool"}` | Annotations for torrent service (e.g., Cilium LB-IPAM) |
+| service | object | `{"torrent":{"annotations":{},"enabled":true,"tcpPort":51413,"type":"LoadBalancer","udpPort":51413},"web":{"annotations":{},"port":9091,"type":"ClusterIP"}}` | Service configuration |
+| service.torrent | object | `{"annotations":{},"enabled":true,"tcpPort":51413,"type":"LoadBalancer","udpPort":51413}` | Separate LoadBalancer service for torrent ports |
+| service.torrent.annotations | object | `{}` | Annotations for torrent service (e.g., Cilium LB-IPAM, MetalLB) |
 | service.torrent.enabled | bool | `true` | Enable separate torrent service |
 | service.torrent.tcpPort | int | `51413` | Torrent TCP port |
 | service.torrent.type | string | `"LoadBalancer"` | Service type for torrent traffic |

--- a/charts/transmission/tests/ingress_test.yaml
+++ b/charts/transmission/tests/ingress_test.yaml
@@ -34,3 +34,24 @@ tests:
       - equal:
           path: spec.tls[0].secretName
           value: transmission-tls
+
+  - it: should have no annotations by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should apply custom annotations when specified
+    set:
+      ingress.enabled: true
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+          value: "100m"
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: "letsencrypt-prod"

--- a/charts/transmission/tests/service_test.yaml
+++ b/charts/transmission/tests/service_test.yaml
@@ -44,6 +44,12 @@ tests:
           path: spec.selector["app.kubernetes.io/instance"]
           value: RELEASE-NAME
 
+  - it: should have no annotations by default for Web UI Service
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
   - it: should support custom annotations for Web UI Service
     set:
       service.web.annotations:
@@ -107,14 +113,13 @@ tests:
           path: spec.selector["app.kubernetes.io/instance"]
           value: RELEASE-NAME
 
-  - it: should set default metallb annotation for Torrent Service
+  - it: should have no annotations by default for Torrent Service
     documentIndex: 1
     asserts:
-      - equal:
-          path: metadata.annotations["metallb.io/address-pool"]
-          value: transmission-pool
+      - notExists:
+          path: metadata.annotations
 
-  - it: should support Cilium LB-IPAM annotation
+  - it: should support custom annotations for Torrent Service
     set:
       service.torrent.annotations:
         io.cilium/lb-ipam-ips: "172.16.100.252"

--- a/charts/transmission/values.schema.json
+++ b/charts/transmission/values.schema.json
@@ -133,7 +133,10 @@
         },
         "annotations": {
           "type": "object",
-          "description": "Ingress annotations"
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Ingress annotations (must be string key-value pairs)"
         },
         "hosts": {
           "type": "array",

--- a/charts/transmission/values.schema.json
+++ b/charts/transmission/values.schema.json
@@ -81,7 +81,10 @@
             },
             "annotations": {
               "type": "object",
-              "description": "Annotations for Web UI service"
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations for Web UI service (must be string key-value pairs)"
             }
           },
           "required": ["type", "port"]
@@ -112,7 +115,10 @@
             },
             "annotations": {
               "type": "object",
-              "description": "Annotations for torrent service (e.g., Cilium LB-IPAM)"
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations for torrent service (must be string key-value pairs)"
             }
           },
           "required": ["enabled", "type", "tcpPort", "udpPort"]
@@ -194,7 +200,10 @@
         },
         "annotations": {
           "type": "object",
-          "description": "HTTPRoute annotations"
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "HTTPRoute annotations (must be string key-value pairs)"
         },
         "parentRefs": {
           "type": "array",
@@ -396,7 +405,10 @@
     },
     "podAnnotations": {
       "type": "object",
-      "description": "Pod annotations"
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Pod annotations (must be string key-value pairs)"
     },
     "podLabels": {
       "type": "object",
@@ -411,7 +423,10 @@
         },
         "annotations": {
           "type": "object",
-          "description": "Annotations to add to the service account"
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the service account (must be string key-value pairs)"
         },
         "name": {
           "type": "string",

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -68,9 +68,7 @@ service:
 ingress:
   enabled: false
   className: ""
-  annotations:
-    traefik.ingress.kubernetes.io/router.entrypoints: "websecure"
-    cert-manager.io/cluster-issuer: "cloudflare-issuer"
+  annotations: {}
   hosts:
     - host: transmission.example.com
       paths:

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -55,10 +55,8 @@ service:
     enabled: true
     # -- Service type for torrent traffic
     type: LoadBalancer
-    # -- Annotations for torrent service (e.g., Cilium LB-IPAM)
-    annotations:
-      # io.cilium/lb-ipam-ips: "172.16.100.252"
-      metallb.io/address-pool: transmission-pool
+    # -- Annotations for torrent service (e.g., Cilium LB-IPAM, MetalLB)
+    annotations: {}
     # -- Torrent TCP port
     tcpPort: 51413
     # -- Torrent UDP port


### PR DESCRIPTION
## Description

Remove environment-specific default annotations from all charts to make them more portable. Add schema validation and unit tests for annotations across all charts.

### Changes per chart

| Chart | Version | Changes |
|-------|---------|---------|
| transmission | 1.2.0 → 1.2.1 | Remove `metallb.io/address-pool`, `traefik`, `cert-manager` annotations |
| cloudflare-tunnel | 0.13.0 → 0.13.1 | Add serviceAccount annotations test and schema validation |
| me-site | 0.5.0 → 0.5.1 | Fix ingress template conditional annotations, add tests |
| system-upgrade-controller | 0.2.0 → 0.2.1 | Add serviceAccount annotations test and schema validation |

### All charts now have

- Schema validation for annotations (`additionalProperties: { type: "string" }`)
- Unit tests verifying no default annotations
- Unit tests for custom annotations

Also configures markdownlint MD060 to "consistent" style for helm-docs generated tables.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes
- [x] Helm lint passes
- [x] Markdownlint passes

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior