### PR TITLE
refactor: simplify renovate config and improve test reliability

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -7,6 +7,8 @@ annotations:
       description: "Add schema validation for annotations (must be string values)"
     - kind: added
       description: "Add unit test for default annotations"
+    - kind: changed
+      description: "Improve test reliability by using regex pattern instead of hardcoded version"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository

--- a/charts/cloudflare-tunnel/tests/deployment_test.yaml
+++ b/charts/cloudflare-tunnel/tests/deployment_test.yaml
@@ -27,10 +27,9 @@ tests:
           path: spec.replicas
           value: 2
       - template: deployment.yaml
-        equal:
+        matchRegex:
           path: spec.template.spec.containers[0].image
-          # renovate: datasource=docker depName=cloudflare/cloudflared
-          value: "cloudflare/cloudflared:2025.10.1"
+          pattern: ^cloudflare/cloudflared:.+$
 
   - it: should use custom image tag when specified
     set:

--- a/renovate.json
+++ b/renovate.json
@@ -8,42 +8,6 @@
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
-  "packageRules": [
-    {
-      "description": "Group cloudflare/cloudflared updates across Chart.yaml and tests",
-      "matchDatasources": ["docker"],
-      "matchDepNames": ["cloudflare/cloudflared"],
-      "groupName": "cloudflare/cloudflared",
-      "commitMessageTopic": "dependency cloudflare/cloudflared"
-    },
-    {
-      "description": "Group linuxserver/transmission updates across Chart.yaml and tests",
-      "matchDatasources": ["docker"],
-      "matchDepNames": ["linuxserver/transmission"],
-      "groupName": "linuxserver/transmission",
-      "commitMessageTopic": "dependency linuxserver/transmission"
-    },
-    {
-      "description": "Auto-bump chart version when appVersion changes",
-      "matchManagers": [
-        "custom.regex"
-      ],
-      "matchFileNames": [
-        "charts/**/Chart.yaml"
-      ],
-      "bumpVersions": [
-        {
-          "filePatterns": [
-            "{{{packageFileDir}}}/Chart.{yaml,yml}"
-          ],
-          "matchStrings": [
-            "version:\\s+[\"']?(?<version>[^\"'\\s]+)[\"']?"
-          ],
-          "bumpType": "{{#if isPatch}}patch{{else}}minor{{/if}}"
-        }
-      ]
-    }
-  ],
   "customManagers": [
     {
       "customType": "regex",
@@ -52,18 +16,6 @@
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?appVersion: \"(?<currentValue>.*?)\""
-      ],
-      "datasourceTemplate": "{{datasource}}",
-      "depNameTemplate": "{{depName}}"
-    },
-    {
-      "customType": "regex",
-      "description": "Update container image versions in Helm unit tests",
-      "fileMatch": [
-        "charts/.+/tests/.+\\.yaml$"
-      ],
-      "matchStrings": [
-        "\\s*# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s*value: [\"'](?:[^:]+):(?<currentValue>[^\"']+)[\"']"
       ],
       "datasourceTemplate": "{{datasource}}",
       "depNameTemplate": "{{depName}}"


### PR DESCRIPTION
## Description

Simplify Renovate configuration by removing unnecessary packageRules. Tests now use regex patterns instead of hardcoded versions, making dependency grouping obsolete.

Changes:
- Remove all packageRules (grouping and auto-bump configurations)
- Update cloudflare-tunnel deployment test to use matchRegex
- Remove customManager for test files from renovate.json
- Bump cloudflare-tunnel chart version

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes
- [x] Helm lint passes

## Additional context

Tests should validate chart functionality, not track dependency versions. This makes the configuration simpler and tests more resilient to version updates.