### PR TITLE
feat(transmission): add extra volumes and PV/PVC support

### DIFF
--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -1,12 +1,14 @@
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
-    - kind: changed
-      description: "Remove all environment-specific default annotations (ingress, service)"
     - kind: added
-      description: "Add schema validation for annotations (must be string values)"
+      description: "Add extraVolumes and extraVolumeMounts for flexible volume configuration"
     - kind: added
-      description: "Add unit tests for annotations"
+      description: "Add extraPersistentVolumes for static PV provisioning"
+    - kind: added
+      description: "Add extraPersistentVolumeClaims for additional PVC creation"
+    - kind: added
+      description: "Add example for separate incomplete downloads directory"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -20,7 +22,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.2.1"
+version: "1.3.0"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.0.6"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.2.1
+  --version 1.3.0
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.2.1 \
+  --version 1.3.0 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.2.1 \
+  ghcr.io/lexfrei/charts/transmission:1.3.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -73,6 +73,10 @@ helm delete transmission
 | env.PGID | string | `"1000"` | Group ID to run as |
 | env.PUID | string | `"1000"` | User ID to run as |
 | env.TZ | string | `"Europe/Moscow"` | Timezone |
+| extraPersistentVolumeClaims | list | [] | Extra PersistentVolumeClaims (created by this chart) |
+| extraPersistentVolumes | list | [] | Extra PersistentVolumes for static provisioning (created by this chart) |
+| extraVolumeMounts | list | [] | Extra volume mounts for the container |
+| extraVolumes | list | [] | Extra volumes to add to the pod (raw Kubernetes volume specs) |
 | fullnameOverride | string | `""` |  |
 | httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":["transmission.example.com"],"parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | HTTPRoute configuration (Gateway API) |
 | httpRoute.hostnames | list | `["transmission.example.com"]` | Hostnames for the route |

--- a/charts/transmission/examples/values-extra-volumes.yaml
+++ b/charts/transmission/examples/values-extra-volumes.yaml
@@ -1,0 +1,78 @@
+# Example: Using extra volumes for separate incomplete downloads directory
+#
+# This example demonstrates how to mount a separate storage location for
+# incomplete downloads. This is useful when you want to:
+# - Keep incomplete files on faster/local storage (SSD)
+# - Keep completed downloads on network storage (NFS/iSCSI)
+# - Reduce wear on network storage from frequent writes
+#
+# IMPORTANT: After deploying, configure the incomplete directory path in
+# Transmission's UI settings: Settings -> Torrents -> Incomplete Directory
+# Set it to: /downloads/incomplete
+#
+# Or use environment variables to configure it automatically.
+
+persistence:
+  config:
+    enabled: true
+    size: 1Gi
+  downloads:
+    enabled: true
+    type: nfs
+    nfsServer: nfs-server.example.com
+    nfsPath: /exports/completed
+
+# Extra volume for incomplete downloads (separate storage)
+extraVolumes:
+  - name: incomplete
+    nfs:
+      server: nfs-server.example.com
+      path: /exports/incomplete
+
+extraVolumeMounts:
+  - name: incomplete
+    mountPath: /downloads/incomplete
+
+# Alternative: Using a PVC for incomplete directory on local/fast storage
+# extraPersistentVolumeClaims:
+#   - name: incomplete
+#     storageClassName: longhorn
+#     accessModes:
+#       - ReadWriteOnce
+#     size: 50Gi
+#
+# extraVolumes:
+#   - name: incomplete
+#     persistentVolumeClaim:
+#       claimName: RELEASE-NAME-transmission-incomplete
+#
+# extraVolumeMounts:
+#   - name: incomplete
+#     mountPath: /downloads/incomplete
+
+# Alternative: Using static PV with NFS for incomplete directory
+# extraPersistentVolumes:
+#   - name: incomplete-pv
+#     capacity: 100Gi
+#     accessModes:
+#       - ReadWriteMany
+#     storageClassName: ""
+#     nfs:
+#       server: 192.168.1.100
+#       path: /exports/incomplete
+#
+# extraPersistentVolumeClaims:
+#   - name: incomplete
+#     accessModes:
+#       - ReadWriteMany
+#     size: 100Gi
+#     volumeName: incomplete-pv
+#
+# extraVolumes:
+#   - name: incomplete
+#     persistentVolumeClaim:
+#       claimName: RELEASE-NAME-transmission-incomplete
+#
+# extraVolumeMounts:
+#   - name: incomplete
+#     mountPath: /downloads/incomplete

--- a/charts/transmission/templates/extra-pv.yaml
+++ b/charts/transmission/templates/extra-pv.yaml
@@ -1,0 +1,42 @@
+{{- range .Values.extraPersistentVolumes }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "transmission.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "transmission.labels" $ | nindent 4 }}
+spec:
+  capacity:
+    storage: {{ .capacity }}
+  accessModes:
+    {{- toYaml .accessModes | nindent 4 }}
+  {{- if .storageClassName }}
+  storageClassName: {{ .storageClassName }}
+  {{- else }}
+  storageClassName: ""
+  {{- end }}
+  {{- if .nfs }}
+  nfs:
+    server: {{ .nfs.server }}
+    path: {{ .nfs.path }}
+  {{- end }}
+  {{- if .hostPath }}
+  hostPath:
+    path: {{ .hostPath.path }}
+    {{- if .hostPath.type }}
+    type: {{ .hostPath.type }}
+    {{- end }}
+  {{- end }}
+  {{- if .local }}
+  local:
+    path: {{ .local.path }}
+  {{- if .nodeAffinity }}
+  nodeAffinity:
+    {{- toYaml .nodeAffinity | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- if .persistentVolumeReclaimPolicy }}
+  persistentVolumeReclaimPolicy: {{ .persistentVolumeReclaimPolicy }}
+  {{- end }}
+{{- end }}

--- a/charts/transmission/templates/extra-pvc.yaml
+++ b/charts/transmission/templates/extra-pvc.yaml
@@ -1,0 +1,23 @@
+{{- range .Values.extraPersistentVolumeClaims }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "transmission.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "transmission.labels" $ | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .size }}
+  {{- if .storageClassName }}
+  storageClassName: {{ .storageClassName }}
+  {{- else if eq .storageClassName "" }}
+  storageClassName: ""
+  {{- end }}
+  {{- if .volumeName }}
+  volumeName: {{ include "transmission.fullname" $ }}-{{ .volumeName }}
+  {{- end }}
+{{- end }}

--- a/charts/transmission/templates/statefulset.yaml
+++ b/charts/transmission/templates/statefulset.yaml
@@ -59,6 +59,9 @@ spec:
               mountPath: /config
             - name: downloads
               mountPath: /downloads
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -85,6 +88,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "transmission.fullname" . }}-downloads
           {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/transmission/tests/extra_persistence_test.yaml
+++ b/charts/transmission/tests/extra_persistence_test.yaml
@@ -1,0 +1,146 @@
+suite: test extra persistence
+templates:
+  - extra-pv.yaml
+  - extra-pvc.yaml
+tests:
+  - it: should not create extra PV when empty
+    template: extra-pv.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create extra PV with NFS
+    template: extra-pv.yaml
+    set:
+      extraPersistentVolumes:
+        - name: test-nfs-pv
+          capacity: 100Gi
+          accessModes:
+            - ReadWriteMany
+          storageClassName: ""
+          nfs:
+            server: 192.168.1.100
+            path: /exports/data
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolume
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-transmission-test-nfs-pv
+      - equal:
+          path: spec.capacity.storage
+          value: 100Gi
+      - equal:
+          path: spec.nfs.server
+          value: "192.168.1.100"
+      - equal:
+          path: spec.nfs.path
+          value: /exports/data
+
+  - it: should create extra PV with hostPath
+    template: extra-pv.yaml
+    set:
+      extraPersistentVolumes:
+        - name: test-hostpath-pv
+          capacity: 50Gi
+          accessModes:
+            - ReadWriteOnce
+          storageClassName: manual
+          hostPath:
+            path: /mnt/data
+            type: DirectoryOrCreate
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolume
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-transmission-test-hostpath-pv
+      - equal:
+          path: spec.hostPath.path
+          value: /mnt/data
+      - equal:
+          path: spec.hostPath.type
+          value: DirectoryOrCreate
+
+  - it: should create multiple extra PVs
+    template: extra-pv.yaml
+    set:
+      extraPersistentVolumes:
+        - name: pv-one
+          capacity: 10Gi
+          accessModes:
+            - ReadWriteOnce
+          hostPath:
+            path: /mnt/one
+        - name: pv-two
+          capacity: 20Gi
+          accessModes:
+            - ReadWriteMany
+          nfs:
+            server: nfs.example.com
+            path: /exports/two
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should not create extra PVC when empty
+    template: extra-pvc.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create extra PVC
+    template: extra-pvc.yaml
+    set:
+      extraPersistentVolumeClaims:
+        - name: test-pvc
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-transmission-test-pvc
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should create extra PVC with volumeName binding
+    template: extra-pvc.yaml
+    set:
+      extraPersistentVolumeClaims:
+        - name: bound-pvc
+          accessModes:
+            - ReadWriteOnce
+          size: 50Gi
+          volumeName: my-pv
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.volumeName
+          value: RELEASE-NAME-transmission-my-pv
+
+  - it: should create multiple extra PVCs
+    template: extra-pvc.yaml
+    set:
+      extraPersistentVolumeClaims:
+        - name: pvc-one
+          accessModes:
+            - ReadWriteOnce
+          size: 10Gi
+        - name: pvc-two
+          accessModes:
+            - ReadWriteMany
+          size: 20Gi
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/charts/transmission/tests/statefulset_test.yaml
+++ b/charts/transmission/tests/statefulset_test.yaml
@@ -164,3 +164,105 @@ tests:
           value: RELEASE-NAME-transmission-downloads
       - isNull:
           path: spec.template.spec.volumes[1].nfs
+
+  # Extra volumes tests
+  - it: should not have extra volumes by default
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 2
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 2
+
+  - it: should add extra volumes when specified
+    set:
+      extraVolumes:
+        - name: extra-data
+          persistentVolumeClaim:
+            claimName: my-existing-pvc
+        - name: temp-storage
+          emptyDir: {}
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 4
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra-data
+            persistentVolumeClaim:
+              claimName: my-existing-pvc
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: temp-storage
+            emptyDir: {}
+
+  - it: should add extra volume mounts when specified
+    set:
+      extraVolumeMounts:
+        - name: extra-data
+          mountPath: /extra-data
+        - name: temp-storage
+          mountPath: /tmp
+          readOnly: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 4
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra-data
+            mountPath: /extra-data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: temp-storage
+            mountPath: /tmp
+            readOnly: true
+
+  - it: should handle extra volumes with subPath
+    set:
+      extraVolumeMounts:
+        - name: shared-volume
+          mountPath: /app/data
+          subPath: app-data
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: shared-volume
+            mountPath: /app/data
+            subPath: app-data
+
+  - it: should add both extra volumes and mounts together
+    set:
+      extraVolumes:
+        - name: incomplete
+          nfs:
+            server: nfs.example.com
+            path: /exports/incomplete
+      extraVolumeMounts:
+        - name: incomplete
+          mountPath: /downloads/incomplete
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 3
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 3
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: incomplete
+            nfs:
+              server: nfs.example.com
+              path: /exports/incomplete
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: incomplete
+            mountPath: /downloads/incomplete

--- a/charts/transmission/values.schema.json
+++ b/charts/transmission/values.schema.json
@@ -477,6 +477,139 @@
         }
       },
       "required": ["enabled"]
+    },
+    "extraVolumes": {
+      "type": "array",
+      "description": "Extra volumes to add to the pod (raw Kubernetes volume specs)",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Volume name"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "description": "Extra volume mounts for the container",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Volume name to mount"
+          },
+          "mountPath": {
+            "type": "string",
+            "description": "Path to mount the volume"
+          },
+          "subPath": {
+            "type": "string",
+            "description": "SubPath within the volume"
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Mount as read-only"
+          }
+        },
+        "required": ["name", "mountPath"]
+      }
+    },
+    "extraPersistentVolumes": {
+      "type": "array",
+      "description": "Extra PersistentVolumes for static provisioning",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "PV name"
+          },
+          "capacity": {
+            "type": "string",
+            "pattern": "^[0-9]+(Mi|Gi|Ti|M|G|T)$",
+            "description": "Storage capacity"
+          },
+          "accessModes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"]
+            },
+            "description": "Access modes"
+          },
+          "storageClassName": {
+            "type": "string",
+            "description": "Storage class name"
+          },
+          "nfs": {
+            "type": "object",
+            "properties": {
+              "server": {
+                "type": "string",
+                "description": "NFS server address"
+              },
+              "path": {
+                "type": "string",
+                "description": "NFS export path"
+              }
+            }
+          },
+          "hostPath": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Host path"
+              },
+              "type": {
+                "type": "string",
+                "enum": ["", "DirectoryOrCreate", "Directory", "FileOrCreate", "File", "Socket", "CharDevice", "BlockDevice"],
+                "description": "Host path type"
+              }
+            }
+          }
+        },
+        "required": ["name", "capacity", "accessModes"]
+      }
+    },
+    "extraPersistentVolumeClaims": {
+      "type": "array",
+      "description": "Extra PersistentVolumeClaims",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "PVC name"
+          },
+          "storageClassName": {
+            "type": "string",
+            "description": "Storage class name"
+          },
+          "accessModes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"]
+            },
+            "description": "Access modes"
+          },
+          "size": {
+            "type": "string",
+            "pattern": "^[0-9]+(Mi|Gi|Ti|M|G|T)$",
+            "description": "Storage size"
+          },
+          "volumeName": {
+            "type": "string",
+            "description": "Bind to specific PV by name"
+          }
+        },
+        "required": ["name", "accessModes", "size"]
+      }
     }
   },
   "required": ["image", "service", "persistence"]

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -186,3 +186,50 @@ networkPolicy:
   ingress: []
   # -- Additional egress rules
   egress: []
+
+# -- Extra volumes to add to the pod (raw Kubernetes volume specs)
+# @default -- []
+extraVolumes: []
+# - name: extra-data
+#   persistentVolumeClaim:
+#     claimName: my-existing-pvc
+# - name: temp-storage
+#   emptyDir: {}
+
+# -- Extra volume mounts for the container
+# @default -- []
+extraVolumeMounts: []
+# - name: extra-data
+#   mountPath: /extra-data
+# - name: temp-storage
+#   mountPath: /tmp
+
+# -- Extra PersistentVolumes for static provisioning (created by this chart)
+# @default -- []
+extraPersistentVolumes: []
+# - name: extra-nfs-pv
+#   capacity: 100Gi
+#   accessModes:
+#     - ReadWriteMany
+#   storageClassName: ""
+#   nfs:
+#     server: 192.168.1.100
+#     path: /exports/data
+# - name: extra-hostpath-pv
+#   capacity: 50Gi
+#   accessModes:
+#     - ReadWriteOnce
+#   storageClassName: manual
+#   hostPath:
+#     path: /mnt/data
+#     type: DirectoryOrCreate
+
+# -- Extra PersistentVolumeClaims (created by this chart)
+# @default -- []
+extraPersistentVolumeClaims: []
+# - name: extra-pvc
+#   storageClassName: ""
+#   accessModes:
+#     - ReadWriteOnce
+#   size: 10Gi
+#   volumeName: extra-nfs-pv  # Optional: bind to specific PV


### PR DESCRIPTION
## Description

Add flexible extra volume configuration options for transmission chart:
- `extraVolumes` and `extraVolumeMounts` for raw Kubernetes volume specs
- `extraPersistentVolumes` for static PV provisioning (NFS, hostPath)
- `extraPersistentVolumeClaims` for additional PVC creation

Includes example for separate incomplete downloads directory configuration.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior