### PR TITLE
feat(cloudflare-tunnel): add sidecar and remote-managed mode support

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -3,8 +3,8 @@ annotations:
   # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
   # See: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update dependency cloudflare/cloudflared to v2025.11.1 - abandoned
+    - kind: added
+      description: Add sidecar containers support
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -18,7 +18,7 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Creation of a cloudflared deployment - a reverse tunnel for an environment
 type: application
-version: "0.14.0"
+version: "0.15.0"
 kubeVersion: ">=1.21.0-0"
 # renovate: datasource=docker depName=cloudflare/cloudflared
 appVersion: "2025.11.1"

--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -5,6 +5,8 @@ annotations:
   artifacthub.io/changes: |-
     - kind: added
       description: Add sidecar containers support
+    - kind: added
+      description: Add remote-managed tunnel mode with token authentication
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -475,16 +475,19 @@ Kubernetes: `>=1.21.0-0`
 | autoscaling.minReplicas | int | `2` | Minimum number of replicas |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` | Target CPU utilization percentage |
 | autoscaling.targetMemoryUtilizationPercentage | string | `nil` | Target memory utilization percentage |
-| cloudflare | object | `{"account":"","enableDefault404":true,"enableWarp":false,"ingress":[],"originRequest":{},"secret":"","secretName":null,"tunnelId":"","tunnelName":""}` | Cloudflare parameters |
-| cloudflare.account | string | `""` | Your Cloudflare account number |
+| cloudflare | object | `{"account":"","enableDefault404":true,"enableWarp":false,"ingress":[],"mode":"local","originRequest":{},"secret":"","secretName":null,"tunnelId":"","tunnelName":"","tunnelToken":"","tunnelTokenSecretName":""}` | Cloudflare parameters |
+| cloudflare.account | string | `""` | Your Cloudflare account number (local mode only) |
 | cloudflare.enableDefault404 | bool | `true` | If true, enable the default 404 page. Needs to be false if you want to use a '*' wildcard rule. |
 | cloudflare.enableWarp | bool | `false` | If true, turn on WARP routing for TCP |
 | cloudflare.ingress | list | `[]` | Define ingress rules for the tunnel See <https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/configuration-file/ingress> |
+| cloudflare.mode | string | `"local"` | Tunnel management mode: "local" or "remote" local: ingress rules defined in values.yaml, stored in ConfigMap remote: ingress rules managed via Cloudflare dashboard/API |
 | cloudflare.originRequest | object | `{}` | Global originRequest configuration for all ingress rules See <https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/configuration/configuration-file/ingress#origin-request> |
-| cloudflare.secret | string | `""` | The secret for the tunnel |
-| cloudflare.secretName | string | `nil` | If defined, no secret is created for the credentials, and instead, the secret referenced is used |
-| cloudflare.tunnelId | string | `""` | The ID of the above tunnel |
-| cloudflare.tunnelName | string | `""` | The name of the tunnel this instance will serve |
+| cloudflare.secret | string | `""` | The secret for the tunnel (local mode only) |
+| cloudflare.secretName | string | `nil` | If defined, no secret is created for the credentials (local mode only) |
+| cloudflare.tunnelId | string | `""` | The ID of the above tunnel (local mode only) |
+| cloudflare.tunnelName | string | `""` | The name of the tunnel this instance will serve (local mode only) |
+| cloudflare.tunnelToken | string | `""` | Tunnel token for remote mode (alternative to credentials file) Get from: Zero Trust Dashboard > Networks > Tunnels > Configure |
+| cloudflare.tunnelTokenSecretName | string | `""` | Secret name containing tunnel token (key: token) If set, tunnelToken value is ignored |
 | deploymentMode | string | `"deployment"` | Deployment mode: "deployment" or "daemonset" DaemonSet mode ensures one tunnel pod per node, useful for: - Preventing port exhaustion from multiple pods on same node - Following Cloudflare's recommendation to limit instances per node - Ensuring predictable distribution and node-level reliability |
 | edgeBindAddress | string | `""` | Edge bind address for outgoing connections Specify the outgoing IP address for tunnel connections to Cloudflare edge Useful for multi-homed servers with multiple network interfaces Leave empty to use system default |
 | edgeIpVersion | string | `""` | IP version for edge connections (auto, 4, 6) auto: Cloudflare selects optimal IP version automatically 4: Force IPv4 connections to Cloudflare edge 6: Force IPv6 connections to Cloudflare edge Leave empty to use cloudflared default |

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.11.1](https://img.shields.io/badge/AppVersion-2025.11.1-informational?style=flat-square)
+![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.11.1](https://img.shields.io/badge/AppVersion-2025.11.1-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -69,7 +69,7 @@ Before installing the chart, create a tunnel in Cloudflare:
 # Install with inline configuration
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.14.0 \
+  --version 0.15.0 \
   --set cloudflare.account=YOUR_ACCOUNT_ID \
   --set cloudflare.tunnelName=YOUR_TUNNEL_NAME \
   --set cloudflare.tunnelId=YOUR_TUNNEL_ID \
@@ -80,7 +80,7 @@ helm install cloudflare-tunnel \
 # Install with values file
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.14.0 \
+  --version 0.15.0 \
   --values values.yaml
 ```
 
@@ -90,7 +90,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.14.0 \
+  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.15.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -526,6 +526,11 @@ Kubernetes: `>=1.21.0-0`
 | serviceMonitor.jobLabel | string | `""` | Job label for the ServiceMonitor |
 | serviceMonitor.metricRelabelings | list | `[]` | Metric relabelings for the ServiceMonitor |
 | serviceMonitor.relabelings | list | `[]` | Relabelings for the ServiceMonitor |
+| sidecar | object | `{"containers":[],"extraVolumeMounts":[],"extraVolumes":[],"initContainers":[]}` | Sidecar configuration for additional containers |
+| sidecar.containers | list | `[]` | Additional sidecar containers All containers share the same network namespace |
+| sidecar.extraVolumeMounts | list | `[]` | Extra volume mounts for the cloudflared container |
+| sidecar.extraVolumes | list | `[]` | Extra volumes for sidecar containers |
+| sidecar.initContainers | list | `[]` | Init containers to run before main containers |
 | tags | object | `{}` | Tags for tunnel identification and monitoring Key-value pairs for tagging tunnel instances in Cloudflare dashboard Useful for grouping, monitoring, and analytics Example: {"environment": "production", "team": "backend"} |
 | tolerations | list | `[]` |  |
 | topologySpreadConstraints | list | `[]` | Topology spread constraints for pod distribution across zones/nodes See <https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/> |

--- a/charts/cloudflare-tunnel/examples/values-awg-sidecar.yaml
+++ b/charts/cloudflare-tunnel/examples/values-awg-sidecar.yaml
@@ -1,0 +1,83 @@
+# Example: Cloudflare Tunnel with AmneziaWG Sidecar
+#
+# Both containers share the same network namespace.
+#
+# Prerequisites:
+# 1. Create config secret:
+#    kubectl create secret generic awg-config \
+#      --from-file=wg0.conf=/path/to/your/config.conf \
+#      --namespace=cloudflared-system
+#
+# 2. Create tunnel credentials secret (if not using cloudflare.secret):
+#    kubectl create secret generic tunnel-credentials \
+#      --from-file=credentials.json=/path/to/credentials.json \
+#      --namespace=cloudflared-system
+#
+# 3. If using Kyverno, create PolicyException for privileged container
+
+cloudflare:
+  account: "your-account-id"
+  tunnelName: "your-tunnel-name"
+  tunnelId: "your-tunnel-id"
+  # Use external secret for credentials
+  secretName: tunnel-credentials
+  ingress:
+    - hostname: app.example.com
+      service: http://my-service.my-namespace.svc.cluster.local:80
+  enableDefault404: true
+
+replicaCount: 1
+
+podSecurityContext:
+  runAsNonRoot: false
+  seccompProfile:
+    type: RuntimeDefault
+
+sidecar:
+  initContainers:
+    - name: wait-for-sidecar
+      image: busybox:1.36
+      command:
+        - sh
+        - -c
+        - |
+          echo "Waiting for sidecar..."
+          sleep 5
+          echo "Done"
+      securityContext:
+        runAsUser: 0
+        runAsNonRoot: false
+
+  containers:
+    - name: amneziawg
+      image: ghcr.io/zeozeozeo/amneziawg-client:latest
+      imagePullPolicy: IfNotPresent
+      stdin: true
+      tty: true
+      securityContext:
+        privileged: true
+        runAsUser: 0
+        runAsNonRoot: false
+      volumeMounts:
+        - name: awg-config
+          mountPath: /config
+          readOnly: true
+        - name: tun-device
+          mountPath: /dev/net/tun
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 64Mi
+
+  extraVolumes:
+    - name: awg-config
+      secret:
+        secretName: awg-config
+    - name: tun-device
+      hostPath:
+        path: /dev/net/tun
+        type: CharDevice
+
+logLevel: info

--- a/charts/cloudflare-tunnel/templates/configmap.yaml
+++ b/charts/cloudflare-tunnel/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.cloudflare.mode "remote" }}
 # This configmap stores the configuration used by cloudflared.
 apiVersion: v1
 kind: ConfigMap
@@ -34,3 +35,4 @@ data:
       # This rule matches any traffic which didn't match a previous rule, and responds with HTTP 404.
       - service: http_status:404
       {{ end }}
+{{- end }}

--- a/charts/cloudflare-tunnel/templates/daemonset.yaml
+++ b/charts/cloudflare-tunnel/templates/daemonset.yaml
@@ -2,8 +2,12 @@
 {{- if and .Values.postQuantum (eq .Values.protocol "http2") }}
 {{- fail "postQuantum cannot be enabled with http2 protocol. Use 'auto' or 'quic' instead." }}
 {{- end }}
+{{- if eq .Values.cloudflare.mode "remote" }}
+{{- if and (not .Values.cloudflare.tunnelToken) (not .Values.cloudflare.tunnelTokenSecretName) }}
+{{- fail "cloudflare.tunnelToken or cloudflare.tunnelTokenSecretName is required when mode is 'remote'" }}
+{{- end }}
+{{- end }}
 # DaemonSet ensures one cloudflared pod per node
-# Useful for preventing port exhaustion and following Cloudflare recommendations
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -49,8 +53,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or (and .Values.logLevel (ne .Values.logLevel "")) (and .Values.protocol (ne .Values.protocol "")) .Values.postQuantum (and .Values.region (ne .Values.region "")) (and .Values.retries (ne .Values.retries "")) (and .Values.edgeIpVersion (ne .Values.edgeIpVersion "")) (and .Values.gracePeriod (ne .Values.gracePeriod "")) (and .Values.edgeBindAddress (ne .Values.edgeBindAddress "")) (and .Values.tags (gt (len .Values.tags) 0)) }}
+          {{- if or (eq .Values.cloudflare.mode "remote") (and .Values.logLevel (ne .Values.logLevel "")) (and .Values.protocol (ne .Values.protocol "")) .Values.postQuantum (and .Values.region (ne .Values.region "")) (and .Values.retries (ne .Values.retries "")) (and .Values.edgeIpVersion (ne .Values.edgeIpVersion "")) (and .Values.gracePeriod (ne .Values.gracePeriod "")) (and .Values.edgeBindAddress (ne .Values.edgeBindAddress "")) (and .Values.tags (gt (len .Values.tags) 0)) }}
           env:
+            {{- if eq .Values.cloudflare.mode "remote" }}
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cloudflare.tunnelTokenSecretName | default (printf "%s-token" (include "cloudflare-tunnel.fullname" .)) }}
+                  key: token
+            {{- end }}
             {{- if and .Values.logLevel (ne .Values.logLevel "") }}
             - name: TUNNEL_LOGLEVEL
               value: {{ .Values.logLevel }}
@@ -90,11 +101,15 @@ spec:
           {{- end }}
           args:
             - tunnel
-            # Points cloudflared to the config file, which configures what
-            # cloudflared will actually do. This file is created by a ConfigMap.
+            {{- if eq .Values.cloudflare.mode "remote" }}
+            - run
+            - --token
+            - $(TUNNEL_TOKEN)
+            {{- else }}
             - --config
             - /etc/cloudflared/config/config.yaml
             - run
+            {{- end }}
           livenessProbe:
             httpGet:
               # Cloudflared has a /ready endpoint which returns 200 if and only if
@@ -107,25 +122,28 @@ spec:
             {{- with .Values.livenessProbe.timeoutSeconds }}
             timeoutSeconds: {{ . }}
             {{- end }}
+          {{- if or (ne .Values.cloudflare.mode "remote") .Values.sidecar.extraVolumeMounts }}
           volumeMounts:
+            {{- if ne .Values.cloudflare.mode "remote" }}
             - name: config
               mountPath: /etc/cloudflared/config
               readOnly: true
-            # Each tunnel has an associated "credentials file" which authorizes machines
-            # to run the tunnel. cloudflared will read this file from its local filesystem,
-            # and it'll be stored in a k8s secret.
             - name: creds
               mountPath: /etc/cloudflared/creds
               readOnly: true
+            {{- end }}
             {{- with .Values.sidecar.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- with .Values.sidecar.containers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if or (ne .Values.cloudflare.mode "remote") .Values.sidecar.extraVolumes }}
       volumes:
+        {{- if ne .Values.cloudflare.mode "remote" }}
         - name: creds
           secret:
             secretName: {{ .Values.cloudflare.secretName | default (include "cloudflare-tunnel.fullname" .) }}
@@ -135,9 +153,11 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        {{- end }}
         {{- with .Values.sidecar.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cloudflare-tunnel/templates/daemonset.yaml
+++ b/charts/cloudflare-tunnel/templates/daemonset.yaml
@@ -39,6 +39,10 @@ spec:
       serviceAccountName: {{ include "cloudflare-tunnel.fullname" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.sidecar.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -113,8 +117,14 @@ spec:
             - name: creds
               mountPath: /etc/cloudflared/creds
               readOnly: true
+            {{- with .Values.sidecar.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- with .Values.sidecar.containers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: creds
           secret:
@@ -125,6 +135,9 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        {{- with .Values.sidecar.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
       serviceAccountName: {{ include "cloudflare-tunnel.fullname" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.sidecar.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -116,8 +120,14 @@ spec:
             - name: creds
               mountPath: /etc/cloudflared/creds
               readOnly: true
+            {{- with .Values.sidecar.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- with .Values.sidecar.containers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: creds
           secret:
@@ -128,6 +138,9 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        {{- with .Values.sidecar.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cloudflare-tunnel/templates/deployment.yaml
+++ b/charts/cloudflare-tunnel/templates/deployment.yaml
@@ -2,8 +2,12 @@
 {{- if and .Values.postQuantum (eq .Values.protocol "http2") }}
 {{- fail "postQuantum cannot be enabled with http2 protocol. Use 'auto' or 'quic' instead." }}
 {{- end }}
-# Here we deploy cloudflared images. The tunnel credentials are stored in
-# a k8s secret, and the configuration is stored in a k8s configmap.
+{{- if eq .Values.cloudflare.mode "remote" }}
+{{- if and (not .Values.cloudflare.tunnelToken) (not .Values.cloudflare.tunnelTokenSecretName) }}
+{{- fail "cloudflare.tunnelToken or cloudflare.tunnelTokenSecretName is required when mode is 'remote'" }}
+{{- end }}
+{{- end }}
+# Here we deploy cloudflared images.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,8 +56,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or (and .Values.logLevel (ne .Values.logLevel "")) (and .Values.protocol (ne .Values.protocol "")) .Values.postQuantum (and .Values.region (ne .Values.region "")) (and .Values.retries (ne .Values.retries "")) (and .Values.edgeIpVersion (ne .Values.edgeIpVersion "")) (and .Values.gracePeriod (ne .Values.gracePeriod "")) (and .Values.edgeBindAddress (ne .Values.edgeBindAddress "")) (and .Values.tags (gt (len .Values.tags) 0)) }}
+          {{- if or (eq .Values.cloudflare.mode "remote") (and .Values.logLevel (ne .Values.logLevel "")) (and .Values.protocol (ne .Values.protocol "")) .Values.postQuantum (and .Values.region (ne .Values.region "")) (and .Values.retries (ne .Values.retries "")) (and .Values.edgeIpVersion (ne .Values.edgeIpVersion "")) (and .Values.gracePeriod (ne .Values.gracePeriod "")) (and .Values.edgeBindAddress (ne .Values.edgeBindAddress "")) (and .Values.tags (gt (len .Values.tags) 0)) }}
           env:
+            {{- if eq .Values.cloudflare.mode "remote" }}
+            - name: TUNNEL_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cloudflare.tunnelTokenSecretName | default (printf "%s-token" (include "cloudflare-tunnel.fullname" .)) }}
+                  key: token
+            {{- end }}
             {{- if and .Values.logLevel (ne .Values.logLevel "") }}
             - name: TUNNEL_LOGLEVEL
               value: {{ .Values.logLevel }}
@@ -93,11 +104,15 @@ spec:
           {{- end }}
           args:
             - tunnel
-            # Points cloudflared to the config file, which configures what
-            # cloudflared will actually do. This file is created by a ConfigMap.
+            {{- if eq .Values.cloudflare.mode "remote" }}
+            - run
+            - --token
+            - $(TUNNEL_TOKEN)
+            {{- else }}
             - --config
             - /etc/cloudflared/config/config.yaml
             - run
+            {{- end }}
           livenessProbe:
             httpGet:
               # Cloudflared has a /ready endpoint which returns 200 if and only if
@@ -110,25 +125,28 @@ spec:
             {{- with .Values.livenessProbe.timeoutSeconds }}
             timeoutSeconds: {{ . }}
             {{- end }}
+          {{- if or (ne .Values.cloudflare.mode "remote") .Values.sidecar.extraVolumeMounts }}
           volumeMounts:
+            {{- if ne .Values.cloudflare.mode "remote" }}
             - name: config
               mountPath: /etc/cloudflared/config
               readOnly: true
-            # Each tunnel has an associated "credentials file" which authorizes machines
-            # to run the tunnel. cloudflared will read this file from its local filesystem,
-            # and it'll be stored in a k8s secret.
             - name: creds
               mountPath: /etc/cloudflared/creds
               readOnly: true
+            {{- end }}
             {{- with .Values.sidecar.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- with .Values.sidecar.containers }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- if or (ne .Values.cloudflare.mode "remote") .Values.sidecar.extraVolumes }}
       volumes:
+        {{- if ne .Values.cloudflare.mode "remote" }}
         - name: creds
           secret:
             secretName: {{ .Values.cloudflare.secretName | default (include "cloudflare-tunnel.fullname" .) }}
@@ -138,9 +156,11 @@ spec:
             items:
               - key: config.yaml
                 path: config.yaml
+        {{- end }}
         {{- with .Values.sidecar.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cloudflare-tunnel/templates/secret-token.yaml
+++ b/charts/cloudflare-tunnel/templates/secret-token.yaml
@@ -1,0 +1,11 @@
+{{- if and (eq .Values.cloudflare.mode "remote") .Values.cloudflare.tunnelToken (not .Values.cloudflare.tunnelTokenSecretName) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cloudflare-tunnel.fullname" . }}-token
+  labels:
+    {{- include "cloudflare-tunnel.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  token: {{ .Values.cloudflare.tunnelToken | quote }}
+{{- end }}

--- a/charts/cloudflare-tunnel/templates/secret.yaml
+++ b/charts/cloudflare-tunnel/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (and .Values.cloudflare.account .Values.cloudflare.tunnelId .Values.cloudflare.secret) (not .Values.cloudflare.secretName) }}
+{{- if and (ne .Values.cloudflare.mode "remote") (and .Values.cloudflare.account .Values.cloudflare.tunnelId .Values.cloudflare.secret) (not .Values.cloudflare.secretName) }}
 # This credentials secret allows cloudflared to authenticate itself
 # to the Cloudflare infrastructure.
 apiVersion: v1

--- a/charts/cloudflare-tunnel/tests/remote_mode_test.yaml
+++ b/charts/cloudflare-tunnel/tests/remote_mode_test.yaml
@@ -1,0 +1,270 @@
+suite: test remote-managed mode
+templates:
+  - deployment.yaml
+  - daemonset.yaml
+  - configmap.yaml
+  - secret.yaml
+  - secret-token.yaml
+values:
+  - ../values.yaml
+tests:
+  # ConfigMap tests
+  - it: should create ConfigMap in local mode (default)
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+    asserts:
+      - template: configmap.yaml
+        hasDocuments:
+          count: 1
+
+  - it: should NOT create ConfigMap in remote mode
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+    asserts:
+      - template: configmap.yaml
+        hasDocuments:
+          count: 0
+
+  # Secret credentials tests
+  - it: should create credentials Secret in local mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+    asserts:
+      - template: secret.yaml
+        hasDocuments:
+          count: 1
+
+  - it: should NOT create credentials Secret in remote mode
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+    asserts:
+      - template: secret.yaml
+        hasDocuments:
+          count: 0
+
+  # Token Secret tests
+  - it: should NOT create token Secret in local mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+    asserts:
+      - template: secret-token.yaml
+        hasDocuments:
+          count: 0
+
+  - it: should create token Secret in remote mode with tunnelToken
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+    asserts:
+      - template: secret-token.yaml
+        hasDocuments:
+          count: 1
+      - template: secret-token.yaml
+        equal:
+          path: stringData.token
+          value: "eyJhIjoiNjM..."
+
+  - it: should NOT create token Secret when tunnelTokenSecretName is set
+    set:
+      cloudflare:
+        mode: remote
+        tunnelTokenSecretName: my-external-secret
+    asserts:
+      - template: secret-token.yaml
+        hasDocuments:
+          count: 0
+
+  # Deployment args tests
+  - it: should use --config args in local mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--config"
+
+  - it: should use --token in remote mode
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--token"
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "$(TUNNEL_TOKEN)"
+
+  # Volume mounts tests
+  - it: should have config and creds volumes in local mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+          any: true
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: creds
+          any: true
+
+  - it: should NOT have config and creds volumes in remote mode
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+    asserts:
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+          any: true
+      - template: deployment.yaml
+        notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: creds
+          any: true
+
+  # Environment variable tests
+  - it: should have TUNNEL_TOKEN env in remote mode
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TUNNEL_TOKEN
+          any: true
+
+  - it: should reference external secret when tunnelTokenSecretName is set
+    set:
+      cloudflare:
+        mode: remote
+        tunnelTokenSecretName: my-external-secret
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[0].env[?(@.name=="TUNNEL_TOKEN")].valueFrom.secretKeyRef.name
+          value: my-external-secret
+
+  # Validation tests
+  - it: should fail in remote mode without token
+    set:
+      cloudflare:
+        mode: remote
+    asserts:
+      - template: deployment.yaml
+        failedTemplate:
+          errorMessage: "cloudflare.tunnelToken or cloudflare.tunnelTokenSecretName is required when mode is 'remote'"
+
+  # DaemonSet tests
+  - it: should use --token in remote mode for DaemonSet
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+      deploymentMode: daemonset
+    asserts:
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.containers[0].args
+          content: "--token"
+
+  - it: should NOT have volumes in remote mode for DaemonSet
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+      deploymentMode: daemonset
+    asserts:
+      - template: daemonset.yaml
+        notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+          any: true
+
+  # Protocol and other flags in remote mode
+  - it: should support protocol flag in remote mode
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+      protocol: http2
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TUNNEL_TRANSPORT_PROTOCOL
+            value: http2
+          any: true
+
+  - it: should support logLevel in remote mode
+    set:
+      cloudflare:
+        mode: remote
+        tunnelToken: "eyJhIjoiNjM..."
+      logLevel: debug
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TUNNEL_LOGLEVEL
+            value: debug
+          any: true

--- a/charts/cloudflare-tunnel/tests/sidecar_test.yaml
+++ b/charts/cloudflare-tunnel/tests/sidecar_test.yaml
@@ -1,0 +1,251 @@
+suite: test sidecar configuration
+templates:
+  - deployment.yaml
+  - daemonset.yaml
+  - configmap.yaml
+  - secret.yaml
+values:
+  - ../values.yaml
+tests:
+  - it: should not render initContainers when sidecar.initContainers is empty
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+    asserts:
+      - template: deployment.yaml
+        isNull:
+          path: spec.template.spec.initContainers
+
+  - it: should render initContainers when configured
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      sidecar:
+        initContainers:
+          - name: wait-for-vpn
+            image: busybox:1.36
+            command: ["sh", "-c", "sleep 5"]
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-vpn
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.36
+
+  - it: should render sidecar containers when configured
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      sidecar:
+        containers:
+          - name: amneziawg
+            image: ghcr.io/zeozeozeo/amneziawg-client:latest
+            stdin: true
+            tty: true
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].name
+          value: amneziawg
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].image
+          value: ghcr.io/zeozeozeo/amneziawg-client:latest
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].stdin
+          value: true
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].tty
+          value: true
+
+  - it: should render extra volumes when configured
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      sidecar:
+        extraVolumes:
+          - name: awg-config
+            secret:
+              secretName: awg-config
+          - name: tun-device
+            hostPath:
+              path: /dev/net/tun
+              type: CharDevice
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: awg-config
+            secret:
+              secretName: awg-config
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tun-device
+            hostPath:
+              path: /dev/net/tun
+              type: CharDevice
+
+  - it: should render extra volume mounts for cloudflared container
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      sidecar:
+        extraVolumeMounts:
+          - name: shared-data
+            mountPath: /shared
+    asserts:
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: shared-data
+            mountPath: /shared
+
+  - it: should work with full AWG sidecar configuration
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      podSecurityContext:
+        runAsNonRoot: false
+      sidecar:
+        initContainers:
+          - name: wait-for-awg
+            image: busybox:1.36
+            command: ["sh", "-c", "sleep 5"]
+            securityContext:
+              runAsUser: 0
+              runAsNonRoot: false
+        containers:
+          - name: amneziawg
+            image: ghcr.io/zeozeozeo/amneziawg-client:latest
+            stdin: true
+            tty: true
+            securityContext:
+              privileged: true
+              runAsUser: 0
+              runAsNonRoot: false
+            volumeMounts:
+              - name: awg-config
+                mountPath: /config
+                readOnly: true
+              - name: tun-device
+                mountPath: /dev/net/tun
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 64Mi
+        extraVolumes:
+          - name: awg-config
+            secret:
+              secretName: awg-config
+          - name: tun-device
+            hostPath:
+              path: /dev/net/tun
+              type: CharDevice
+    asserts:
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-awg
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].name
+          value: amneziawg
+      - template: deployment.yaml
+        equal:
+          path: spec.template.spec.containers[1].securityContext.privileged
+          value: true
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tun-device
+            hostPath:
+              path: /dev/net/tun
+              type: CharDevice
+
+  - it: should support sidecar in DaemonSet mode
+    set:
+      cloudflare:
+        account: test-account
+        tunnelName: test-tunnel
+        tunnelId: test-id
+        secret: test-secret
+        ingress:
+          - hostname: test.example.com
+            service: http://test-service:80
+      deploymentMode: daemonset
+      sidecar:
+        initContainers:
+          - name: wait-for-vpn
+            image: busybox:1.36
+            command: ["sh", "-c", "sleep 5"]
+        containers:
+          - name: amneziawg
+            image: ghcr.io/zeozeozeo/amneziawg-client:latest
+        extraVolumes:
+          - name: awg-config
+            secret:
+              secretName: awg-config
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-vpn
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[1].name
+          value: amneziawg
+      - template: daemonset.yaml
+        contains:
+          path: spec.template.spec.volumes
+          content:
+            name: awg-config
+            secret:
+              secretName: awg-config

--- a/charts/cloudflare-tunnel/values.schema.json
+++ b/charts/cloudflare-tunnel/values.schema.json
@@ -406,6 +406,44 @@
         "type": "string"
       },
       "default": {}
+    },
+    "sidecar": {
+      "type": "object",
+      "description": "Sidecar configuration for additional containers",
+      "properties": {
+        "initContainers": {
+          "type": "array",
+          "description": "Init containers to run before main containers",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "containers": {
+          "type": "array",
+          "description": "Additional sidecar containers",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "extraVolumes": {
+          "type": "array",
+          "description": "Extra volumes for sidecar containers",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        },
+        "extraVolumeMounts": {
+          "type": "array",
+          "description": "Extra volume mounts for the cloudflared container",
+          "items": {
+            "type": "object"
+          },
+          "default": []
+        }
+      }
     }
   },
   "required": [

--- a/charts/cloudflare-tunnel/values.schema.json
+++ b/charts/cloudflare-tunnel/values.schema.json
@@ -6,28 +6,42 @@
     "cloudflare": {
       "type": "object",
       "properties": {
+        "mode": {
+          "type": "string",
+          "description": "Tunnel management mode: local or remote.",
+          "enum": ["local", "remote"],
+          "default": "local"
+        },
+        "tunnelToken": {
+          "type": "string",
+          "description": "Tunnel token for remote mode."
+        },
+        "tunnelTokenSecretName": {
+          "type": "string",
+          "description": "Secret name containing tunnel token (key: token)."
+        },
         "account": {
           "type": "string",
-          "description": "Your Cloudflare account number."
+          "description": "Your Cloudflare account number (local mode only)."
         },
         "tunnelName": {
           "type": "string",
-          "description": "The name of the tunnel this instance will serve."
+          "description": "The name of the tunnel (local mode only)."
         },
         "tunnelId": {
           "type": "string",
-          "description": "The ID of the above tunnel."
+          "description": "The ID of the tunnel (local mode only)."
         },
         "secret": {
           "type": "string",
-          "description": "The secret for the tunnel."
+          "description": "The secret for the tunnel (local mode only)."
         },
         "secretName": {
           "type": [
             "string",
             "null"
           ],
-          "description": "Reference to a secret if no credentials are created."
+          "description": "Reference to a secret (local mode only)."
         },
         "enableWarp": {
           "type": "boolean",
@@ -121,10 +135,26 @@
           }
         }
       },
-      "required": [
-        "account",
-        "tunnelName",
-        "tunnelId"
+      "allOf": [
+        {
+          "if": {
+            "properties": { "mode": { "const": "local" } }
+          },
+          "then": {
+            "required": ["account", "tunnelName", "tunnelId"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "mode": { "const": "remote" } }
+          },
+          "then": {
+            "anyOf": [
+              { "required": ["tunnelToken"] },
+              { "required": ["tunnelTokenSecretName"] }
+            ]
+          }
+        }
       ]
     },
     "image": {

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -215,6 +215,24 @@ edgeBindAddress: ""
 # Example: {"environment": "production", "team": "backend"}
 tags: {}
 
+# -- Sidecar configuration for additional containers
+sidecar:
+  # -- Init containers to run before main containers
+  initContainers: []
+    # - name: init-setup
+    #   image: busybox:1.36
+    #   command: ["sh", "-c", "sleep 5"]
+
+  # -- Additional sidecar containers
+  # All containers share the same network namespace
+  containers: []
+
+  # -- Extra volumes for sidecar containers
+  extraVolumes: []
+
+  # -- Extra volume mounts for the cloudflared container
+  extraVolumeMounts: []
+
 # -- Network Policy configuration
 networkPolicy:
   # -- Enable NetworkPolicy

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -2,15 +2,27 @@
 
 # -- Cloudflare parameters
 cloudflare:
-  # -- Your Cloudflare account number
+  # -- Tunnel management mode: "local" or "remote"
+  # local: ingress rules defined in values.yaml, stored in ConfigMap
+  # remote: ingress rules managed via Cloudflare dashboard/API
+  mode: local
+
+  # -- Tunnel token for remote mode (alternative to credentials file)
+  # Get from: Zero Trust Dashboard > Networks > Tunnels > Configure
+  tunnelToken: ""
+  # -- Secret name containing tunnel token (key: token)
+  # If set, tunnelToken value is ignored
+  tunnelTokenSecretName: ""
+
+  # -- Your Cloudflare account number (local mode only)
   account: ""
-  # -- The name of the tunnel this instance will serve
+  # -- The name of the tunnel this instance will serve (local mode only)
   tunnelName: ""
-  # -- The ID of the above tunnel
+  # -- The ID of the above tunnel (local mode only)
   tunnelId: ""
-  # -- The secret for the tunnel
+  # -- The secret for the tunnel (local mode only)
   secret: ""
-  # -- If defined, no secret is created for the credentials, and instead, the secret referenced is used
+  # -- If defined, no secret is created for the credentials (local mode only)
   secretName: null
   # -- If true, turn on WARP routing for TCP
   enableWarp: false


### PR DESCRIPTION
## Description

Add two major features to cloudflare-tunnel chart:
1. **Sidecar containers support** - enables additional containers in the pod
2. **Remote-managed tunnel mode** - ingress rules managed via Cloudflare dashboard/API

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes
- [x] Helm lint passes

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior

## Additional context

### New values

**Sidecar support:**
- `sidecar.initContainers` - init containers
- `sidecar.containers` - sidecar containers  
- `sidecar.extraVolumes` - additional volumes
- `sidecar.extraVolumeMounts` - additional mounts for cloudflared

**Remote mode:**
- `cloudflare.mode` - `local` (default) or `remote`
- `cloudflare.tunnelToken` - token for remote mode
- `cloudflare.tunnelTokenSecretName` - external secret reference

### Schema validation

Conditional validation ensures:
- `local` mode requires: account, tunnelName, tunnelId
- `remote` mode requires: tunnelToken OR tunnelTokenSecretName