### PR TITLE
fix(vipalived): update chart icon to full Keepalived logo

### DIFF
--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -1,14 +1,8 @@
 annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
-    - kind: added
-      description: Add liveness probe for keepalived process monitoring
-    - kind: added
-      description: Add chart icon
     - kind: fixed
-      description: Fix NOTES.txt to use correct namespace from values
-    - kind: changed
-      description: Remove unused serviceAccountName helper
+      description: Update chart icon to full Keepalived logo
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -22,7 +16,7 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.5.0
+version: 0.5.1
 # renovate: datasource=docker depName=alpine
 appVersion: "3.22"
 keywords:
@@ -35,5 +29,5 @@ keywords:
 maintainers:
   - name: lexfrei
     email: f@lex.la
-icon: https://www.keepalived.org/images/ka_favicon.png
+icon: https://keepalived.org/images/Keepalived-LOGO.png
 kubeVersion: '>=1.16.0-0'

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -1,6 +1,6 @@
 # vipalived
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.22](https://img.shields.io/badge/AppVersion-3.22-informational?style=flat-square)
+![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.22](https://img.shields.io/badge/AppVersion-3.22-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -16,16 +16,16 @@ Keepalived-based VIP management for Kubernetes control plane high availability
 
 ```bash
 # Day 2: Install with default VIP (172.16.101.101/32) on existing cluster
-helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.5.0
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.5.1
 
 # Day 2: Install with custom VIP address
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.5.0 \
+  --version 0.5.1 \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
 
 # Day 1: Generate static pod manifest for cluster bootstrap
 helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.5.0 \
+  --version 0.5.1 \
   --set static=true \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
 ```
@@ -75,7 +75,7 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 
    ```bash
    helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-     --version 0.5.0 \
+     --version 0.5.1 \
      --set static=true \
      --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR \
      --namespace kube-system > vipalived-static-pod.yaml
@@ -138,7 +138,7 @@ All charts published to GHCR are signed using cosign. To verify the chart signat
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/vipalived:0.5.0 \
+  ghcr.io/lexfrei/charts/vipalived:0.5.1 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```


### PR DESCRIPTION
## Summary
- Update vipalived chart icon from favicon to full Keepalived logo for better visibility on Artifact Hub

## Test plan
- [x] `helm lint` passes
- [x] Schema validation passes
- [x] Unit tests pass (80 tests)