### PR TITLE
ci(publish-oci): fix helm-unittest plugin installation and flags

### DIFF
--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Install helm-unittest plugin
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git --verify=false
 
       - name: Install check-jsonschema
         run: pip install check-jsonschema
@@ -186,7 +186,7 @@ jobs:
 
           # Unit tests (if tests exist)
           if [ -d "${CHART_PATH}/tests" ]; then
-            helm unittest "${CHART_PATH}" --color
+            helm unittest "${CHART_PATH}" --with-subchart=false
           else
             echo "No tests found, skipping unit tests"
           fi


### PR DESCRIPTION
# Pull Request

## Description

Fix helm-unittest issues in publish-oci workflow:
- Add `--verify=false` flag to plugin installation (plugin source does not support verification)
- Replace `--color` flag with `--with-subchart=false` (avoids conflict with chart-testing wrapper)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code