### PR TITLE
fix(transmission): use combined exec liveness probe to detect NFS mount failures

### DIFF
--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -1,12 +1,8 @@
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
-    - kind: added
-      description: "Add configurable liveness and readiness probes"
-    - kind: fixed
-      description: "Fix NOTES.txt ingress URL variable scope"
-    - kind: fixed
-      description: "Fix updateStrategy schema to use valid StatefulSet values"
+    - kind: changed
+      description: "Use combined exec liveness probe to detect NFS mount failures"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -20,7 +16,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.4.0"
+version: "1.4.1"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.0.6"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
+![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.4.0
+  --version 1.4.1
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.4.0 \
+  --version 1.4.1 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.4.0 \
+  ghcr.io/lexfrei/charts/transmission:1.4.1 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -87,8 +87,9 @@ helm delete transmission
 | imagePullSecrets | list | `[]` |  |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"transmission.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["transmission.example.com"],"secretName":"transmission-tls"}]}` | Ingress configuration |
 | initContainers | list | [] | Init containers to run before the main container |
-| livenessProbe | object | `{"failureThreshold":6,"initialDelaySeconds":30,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| livenessProbe | object | `{"failureThreshold":6,"fsCheckPath":"/downloads","initialDelaySeconds":30,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
 | livenessProbe.failureThreshold | int | `6` | Failure threshold for liveness probe |
+| livenessProbe.fsCheckPath | string | `"/downloads"` | Path to check for write access (detects NFS mount failures) |
 | livenessProbe.initialDelaySeconds | int | `30` | Initial delay before liveness probe starts |
 | livenessProbe.periodSeconds | int | `10` | Period between liveness probe checks |
 | livenessProbe.timeoutSeconds | int | `5` | Timeout for liveness probe |

--- a/charts/transmission/templates/statefulset.yaml
+++ b/charts/transmission/templates/statefulset.yaml
@@ -55,9 +55,11 @@ spec:
               containerPort: 51413
               protocol: UDP
           livenessProbe:
-            httpGet:
-              path: /transmission/web/
-              port: http
+            exec:
+              command:
+                - sh
+                - -c
+                - test -w {{ .Values.livenessProbe.fsCheckPath }} && curl -sf http://localhost:9091/transmission/web/ >/dev/null
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/charts/transmission/tests/statefulset_test.yaml
+++ b/charts/transmission/tests/statefulset_test.yaml
@@ -79,14 +79,17 @@ tests:
           value: RuntimeDefault
 
   # Health probes tests
-  - it: should have liveness probe with default values
+  - it: should have liveness probe with exec command and default values
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
-          value: /transmission/web/
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
+          value: sh
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-          value: http
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[1]
+          value: -c
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          value: "test -w /downloads && curl -sf http://localhost:9091/transmission/web/ >/dev/null"
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
           value: 30
@@ -124,11 +127,15 @@ tests:
   - it: should allow custom liveness probe values
     set:
       livenessProbe:
+        fsCheckPath: /data
         initialDelaySeconds: 60
         periodSeconds: 20
         timeoutSeconds: 10
         failureThreshold: 3
     asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          value: "test -w /data && curl -sf http://localhost:9091/transmission/web/ >/dev/null"
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
           value: 60

--- a/charts/transmission/values.schema.json
+++ b/charts/transmission/values.schema.json
@@ -301,6 +301,11 @@
       "type": "object",
       "description": "Liveness probe configuration",
       "properties": {
+        "fsCheckPath": {
+          "type": "string",
+          "description": "Path to check for write access (detects NFS mount failures)",
+          "default": "/downloads"
+        },
         "initialDelaySeconds": {
           "type": "integer",
           "description": "Initial delay before liveness probe starts",

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -107,6 +107,8 @@ resources:
 
 # -- Liveness probe configuration
 livenessProbe:
+  # -- Path to check for write access (detects NFS mount failures)
+  fsCheckPath: /downloads
   # -- Initial delay before liveness probe starts
   initialDelaySeconds: 30
   # -- Period between liveness probe checks


### PR DESCRIPTION
# Pull Request

## Description

Liveness probe now checks both filesystem write access and HTTP response. This detects situations where NFS mount fails with I/O errors but the Transmission process stays alive and responds to HTTP — making the pod effectively useless but still "healthy" from Kubernetes perspective.

The probe command:
```sh
test -w /downloads && curl -sf http://localhost:9091/transmission/web/ >/dev/null
```

New value `livenessProbe.fsCheckPath` allows configuring the path to check (default: `/downloads`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If adding new templates

- [ ] Templates follow Helm best practices
- [ ] Templates use proper indentation (`nindent` instead of `indent`)
- [ ] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior

## Additional context

Readiness probe stays as HTTP-only since it only needs to verify the web UI is ready to accept traffic.