### PR TITLE
fix(transmission): use touch/rm to detect NFS I/O errors in liveness probe

### DIFF
--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -1,8 +1,8 @@
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
-    - kind: changed
-      description: "Use combined exec liveness probe to detect NFS mount failures"
+    - kind: fixed
+      description: "Use touch/rm instead of test -w to actually detect NFS I/O errors"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +16,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.4.1"
+version: "1.4.2"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.0.6"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.4.1
+  --version 1.4.2
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.4.1 \
+  --version 1.4.2 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.4.1 \
+  ghcr.io/lexfrei/charts/transmission:1.4.2 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/transmission/templates/statefulset.yaml
+++ b/charts/transmission/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
               command:
                 - sh
                 - -c
-                - test -w {{ .Values.livenessProbe.fsCheckPath }} && curl -sf http://localhost:9091/transmission/web/ >/dev/null
+                - touch {{ .Values.livenessProbe.fsCheckPath }}/.healthcheck && rm --force {{ .Values.livenessProbe.fsCheckPath }}/.healthcheck && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/charts/transmission/tests/statefulset_test.yaml
+++ b/charts/transmission/tests/statefulset_test.yaml
@@ -89,7 +89,7 @@ tests:
           value: -c
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
-          value: "test -w /downloads && curl -sf http://localhost:9091/transmission/web/ >/dev/null"
+          value: "touch /downloads/.healthcheck && rm --force /downloads/.healthcheck && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null"
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
           value: 30
@@ -135,7 +135,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
-          value: "test -w /data && curl -sf http://localhost:9091/transmission/web/ >/dev/null"
+          value: "touch /data/.healthcheck && rm --force /data/.healthcheck && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null"
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
           value: 60


### PR DESCRIPTION
# Pull Request

## Description

`test -w` only checks permissions, not actual I/O capability. When NFS mount hangs with I/O errors, `test -w` may still pass since the kernel caches directory metadata.

This fix uses `touch && rm` which performs real write operation that will fail on hung NFS.

Also adds `--max-time 5` to curl to prevent hanging on unresponsive service.

New probe command:
```sh
touch /downloads/.healthcheck && rm --force /downloads/.healthcheck && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior