### PR TITLE
fix(vipalived): remove hardcoded alpine version from tests

### DIFF
--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
     - kind: fixed
-      description: Update chart icon to full Keepalived logo
+      description: Remove hardcoded alpine version from tests to prevent Renovate update failures
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +16,7 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.5.1
+version: 0.5.2
 # renovate: datasource=docker depName=alpine
 appVersion: "3.22"
 keywords:

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -1,6 +1,6 @@
 # vipalived
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.22](https://img.shields.io/badge/AppVersion-3.22-informational?style=flat-square)
+![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.22](https://img.shields.io/badge/AppVersion-3.22-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -16,16 +16,16 @@ Keepalived-based VIP management for Kubernetes control plane high availability
 
 ```bash
 # Day 2: Install with default VIP (172.16.101.101/32) on existing cluster
-helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.5.1
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.5.2
 
 # Day 2: Install with custom VIP address
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
 
 # Day 1: Generate static pod manifest for cluster bootstrap
 helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.5.1 \
+  --version 0.5.2 \
   --set static=true \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
 ```
@@ -75,7 +75,7 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 
    ```bash
    helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-     --version 0.5.1 \
+     --version 0.5.2 \
      --set static=true \
      --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR \
      --namespace kube-system > vipalived-static-pod.yaml
@@ -138,7 +138,7 @@ All charts published to GHCR are signed using cosign. To verify the chart signat
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/vipalived:0.5.1 \
+  ghcr.io/lexfrei/charts/vipalived:0.5.2 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/vipalived/tests/daemonset_test.yaml
+++ b/charts/vipalived/tests/daemonset_test.yaml
@@ -107,10 +107,9 @@ tests:
           path: spec.template.spec.containers[0].name
           value: keepalived
       - template: daemonset.yaml
-        equal:
+        matchRegex:
           path: spec.template.spec.containers[0].image
-          # renovate: datasource=docker depName=alpine
-          value: alpine:3.22
+          pattern: ^alpine:.+$
       - template: daemonset.yaml
         equal:
           path: spec.template.spec.containers[0].imagePullPolicy

--- a/charts/vipalived/tests/pod_test.yaml
+++ b/charts/vipalived/tests/pod_test.yaml
@@ -87,11 +87,11 @@ tests:
       static: true
       image:
         repository: alpine
-        tag: "3.22"
+        tag: "test-tag"
     asserts:
       - equal:
           path: spec.containers[0].image
-          value: alpine:3.22
+          value: alpine:test-tag
 
   - it: should not have ConfigMap volumes
     set:


### PR DESCRIPTION
# Pull Request

## Description

Fix tests to verify tag passthrough mechanism instead of checking hardcoded alpine version. This prevents test failures when Renovate updates `appVersion` in Chart.yaml.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior

## Additional context

N/A