### PR TITLE
feat(transmission): add extraContainers support for sidecars

### DIFF
--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -1,8 +1,8 @@
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
-    - kind: fixed
-      description: "Use touch/rm instead of test -w to actually detect NFS I/O errors"
+    - kind: added
+      description: "Add extraContainers support for sidecar containers (VPN, logging, etc.)"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +16,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.4.2"
+version: "1.5.0"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.0.6"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.4.2
+  --version 1.5.0
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.4.2 \
+  --version 1.5.0 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.4.2 \
+  ghcr.io/lexfrei/charts/transmission:1.5.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -73,6 +73,7 @@ helm delete transmission
 | env.PGID | string | `"1000"` | Group ID to run as |
 | env.PUID | string | `"1000"` | User ID to run as |
 | env.TZ | string | `"Europe/Moscow"` | Timezone |
+| extraContainers | list | [] | Extra containers to run alongside transmission (sidecars) Useful for VPN containers like gluetun |
 | extraPersistentVolumeClaims | list | [] | Extra PersistentVolumeClaims (created by this chart) |
 | extraPersistentVolumes | list | [] | Extra PersistentVolumes for static provisioning (created by this chart) |
 | extraVolumeMounts | list | [] | Extra volume mounts for the container |

--- a/charts/transmission/examples/README.md
+++ b/charts/transmission/examples/README.md
@@ -127,7 +127,50 @@ persistence:
 
 ---
 
-### 4. Production Configuration (`values-production.yaml`) 🚀
+### 4. VPN Sidecar with Gluetun (`values-vpn-sidecar.yaml`) 🔒
+
+**Use case**: Route all Transmission traffic through a VPN for privacy.
+
+**Features**:
+- Gluetun VPN client as sidecar container
+- All torrent traffic goes through VPN tunnel
+- Supports OpenVPN and WireGuard
+- Works with most VPN providers
+
+**Prerequisites**:
+
+1. Create a secret with VPN credentials:
+
+```bash
+# For OpenVPN
+kubectl create secret generic gluetun-config \
+  --from-literal=OPENVPN_USER=your-username \
+  --from-literal=OPENVPN_PASSWORD=your-password \
+  --namespace media
+
+# For WireGuard
+kubectl create secret generic gluetun-config \
+  --from-literal=WIREGUARD_PRIVATE_KEY=your-private-key \
+  --from-literal=WIREGUARD_ADDRESSES=10.x.x.x/32 \
+  --namespace media
+```
+
+2. Install Transmission with VPN sidecar:
+
+```bash
+helm install transmission oci://ghcr.io/lexfrei/charts/transmission \
+  --values examples/values-vpn-sidecar.yaml \
+  --namespace media
+```
+
+**Configuration**:
+- Modify `VPN_SERVICE_PROVIDER` for your provider
+- See [gluetun wiki](https://github.com/qdm12/gluetun-wiki) for provider-specific settings
+- Adjust `FIREWALL_OUTBOUND_SUBNETS` for your cluster network
+
+---
+
+### 5. Production Configuration (`values-production.yaml`) 🚀
 
 **Use case**: Full production deployment with security, monitoring, and shared storage.
 

--- a/charts/transmission/examples/values-vpn-sidecar.yaml
+++ b/charts/transmission/examples/values-vpn-sidecar.yaml
@@ -1,0 +1,118 @@
+# Example: VPN sidecar with gluetun
+#
+# This example demonstrates how to run Transmission behind a VPN using
+# gluetun as a sidecar container. All traffic from Transmission will
+# go through the VPN tunnel.
+#
+# IMPORTANT: You need to create a secret with your VPN credentials first:
+#
+# kubectl create secret generic gluetun-config \
+#   --from-literal=OPENVPN_USER=your-username \
+#   --from-literal=OPENVPN_PASSWORD=your-password \
+#   --namespace media
+#
+# Or for WireGuard:
+#
+# kubectl create secret generic gluetun-config \
+#   --from-literal=WIREGUARD_PRIVATE_KEY=your-private-key \
+#   --from-literal=WIREGUARD_ADDRESSES=10.x.x.x/32 \
+#   --namespace media
+
+# Pod security context - gluetun needs NET_ADMIN capability
+podSecurityContext:
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# Main transmission container security context
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    add:
+      - SETUID
+      - SETGID
+      - CHOWN
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false
+
+# Gluetun VPN sidecar container
+extraContainers:
+  - name: gluetun
+    image: qmcgaw/gluetun:latest
+    securityContext:
+      capabilities:
+        add:
+          - NET_ADMIN
+    env:
+      # VPN provider configuration
+      # See https://github.com/qdm12/gluetun-wiki for all providers
+      - name: VPN_SERVICE_PROVIDER
+        value: "custom"
+      - name: VPN_TYPE
+        value: "openvpn"
+      # Server configuration
+      - name: OPENVPN_CUSTOM_CONFIG
+        value: "/gluetun/config.ovpn"
+      # Credentials from secret
+      - name: OPENVPN_USER
+        valueFrom:
+          secretKeyRef:
+            name: gluetun-config
+            key: OPENVPN_USER
+      - name: OPENVPN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: gluetun-config
+            key: OPENVPN_PASSWORD
+      # Firewall settings - allow Transmission ports
+      - name: FIREWALL_INPUT_PORTS
+        value: "9091"
+      - name: FIREWALL_OUTBOUND_SUBNETS
+        value: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+    ports:
+      - name: http
+        containerPort: 9091
+        protocol: TCP
+    volumeMounts:
+      - name: gluetun-config
+        mountPath: /gluetun
+        readOnly: true
+      - name: tun-device
+        mountPath: /dev/net/tun
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi
+
+# Extra volumes for gluetun
+extraVolumes:
+  - name: gluetun-config
+    secret:
+      secretName: gluetun-config
+  - name: tun-device
+    hostPath:
+      path: /dev/net/tun
+      type: CharDevice
+
+# Storage configuration
+persistence:
+  config:
+    enabled: true
+    size: 1Gi
+  downloads:
+    enabled: true
+    type: pvc
+    storageClassName: ""
+    size: 100Gi
+
+# Resources for transmission container
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "100m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"

--- a/charts/transmission/templates/statefulset.yaml
+++ b/charts/transmission/templates/statefulset.yaml
@@ -82,6 +82,9 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       volumes:
         - name: config
           {{- if .Values.persistence.config.existingClaim }}

--- a/charts/transmission/tests/statefulset_test.yaml
+++ b/charts/transmission/tests/statefulset_test.yaml
@@ -358,3 +358,71 @@ tests:
           content:
             name: incomplete
             mountPath: /downloads/incomplete
+
+  # Extra containers (sidecar) tests
+  - it: should not have extra containers by default
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 1
+
+  - it: should render extra containers when configured
+    set:
+      extraContainers:
+        - name: sidecar
+          image: busybox:latest
+          command: ["sh", "-c", "sleep infinity"]
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: sidecar
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: busybox:latest
+
+  - it: should work with gluetun VPN sidecar configuration
+    set:
+      extraContainers:
+        - name: gluetun
+          image: qmcgaw/gluetun:latest
+          securityContext:
+            capabilities:
+              add:
+                - NET_ADMIN
+          env:
+            - name: VPN_SERVICE_PROVIDER
+              value: "custom"
+          volumeMounts:
+            - name: gluetun-config
+              mountPath: /gluetun
+      extraVolumes:
+        - name: gluetun-config
+          secret:
+            secretName: gluetun-config
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: gluetun
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: qmcgaw/gluetun:latest
+      - contains:
+          path: spec.template.spec.containers[1].securityContext.capabilities.add
+          content: NET_ADMIN
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: VPN_SERVICE_PROVIDER
+            value: "custom"
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: gluetun-config
+            secret:
+              secretName: gluetun-config

--- a/charts/transmission/values.schema.json
+++ b/charts/transmission/values.schema.json
@@ -509,6 +509,13 @@
       },
       "description": "Init containers to run before the main container"
     },
+    "extraContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Extra containers to run alongside transmission (sidecars)"
+    },
     "podSecurityContext": {
       "type": "object",
       "description": "Security context for the pod"

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -202,6 +202,24 @@ initContainers: []
 #   securityContext:
 #     runAsUser: 0
 
+# -- Extra containers to run alongside transmission (sidecars)
+# Useful for VPN containers like gluetun
+# @default -- []
+extraContainers: []
+# Example with gluetun VPN:
+# - name: gluetun
+#   image: qmcgaw/gluetun:latest
+#   securityContext:
+#     capabilities:
+#       add:
+#         - NET_ADMIN
+#   env:
+#     - name: VPN_SERVICE_PROVIDER
+#       value: "custom"
+#   volumeMounts:
+#     - name: gluetun-config
+#       mountPath: /gluetun
+
 # -- Network Policy configuration
 networkPolicy:
   # -- Enable NetworkPolicy


### PR DESCRIPTION
# Pull Request

## Description

Add `extraContainers` support for running sidecar containers alongside transmission. Primary use case: VPN containers like gluetun for secure torrenting.

Closes #152

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior

## Additional context

This follows the same pattern as `initContainers`, `extraVolumes`, and `extraVolumeMounts` already present in the chart. The implementation mirrors the sidecar support in the cloudflare-tunnel chart.