### PR TITLE
feat(transmission): add runAsUser option for liveness probe

### DIFF
--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
     - kind: added
-      description: "Add extraContainers support for sidecar containers (VPN, logging, etc.)"
+      description: "Add livenessProbe.runAsUser option (default 'abc') to fix NFS permission issues"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +16,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.5.0"
+version: "1.6.0"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.0.6"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
+![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.5.0
+  --version 1.6.0
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.5.0 \
+  --version 1.6.0 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.5.0 \
+  ghcr.io/lexfrei/charts/transmission:1.6.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -88,11 +88,12 @@ helm delete transmission
 | imagePullSecrets | list | `[]` |  |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"transmission.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["transmission.example.com"],"secretName":"transmission-tls"}]}` | Ingress configuration |
 | initContainers | list | [] | Init containers to run before the main container |
-| livenessProbe | object | `{"failureThreshold":6,"fsCheckPath":"/downloads","initialDelaySeconds":30,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| livenessProbe | object | `{"failureThreshold":6,"fsCheckPath":"/downloads","initialDelaySeconds":30,"periodSeconds":10,"runAsUser":"abc","timeoutSeconds":5}` | Liveness probe configuration |
 | livenessProbe.failureThreshold | int | `6` | Failure threshold for liveness probe |
 | livenessProbe.fsCheckPath | string | `"/downloads"` | Path to check for write access (detects NFS mount failures) |
 | livenessProbe.initialDelaySeconds | int | `30` | Initial delay before liveness probe starts |
 | livenessProbe.periodSeconds | int | `10` | Period between liveness probe checks |
+| livenessProbe.runAsUser | string | `"abc"` | User to run filesystem check as (linuxserver images use 'abc') |
 | livenessProbe.timeoutSeconds | int | `5` | Timeout for liveness probe |
 | nameOverride | string | `""` |  |
 | networkPolicy | object | `{"egress":[],"enabled":false,"ingress":[]}` | Network Policy configuration |

--- a/charts/transmission/templates/statefulset.yaml
+++ b/charts/transmission/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
               command:
                 - sh
                 - -c
-                - touch {{ .Values.livenessProbe.fsCheckPath }}/.healthcheck && rm --force {{ .Values.livenessProbe.fsCheckPath }}/.healthcheck && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null
+                - {{ if .Values.livenessProbe.runAsUser }}su -s /bin/sh - {{ .Values.livenessProbe.runAsUser }} -c 'touch {{ .Values.livenessProbe.fsCheckPath }}/.healthcheck && rm --force {{ .Values.livenessProbe.fsCheckPath }}/.healthcheck'{{ else }}touch {{ .Values.livenessProbe.fsCheckPath }}/.healthcheck && rm --force {{ .Values.livenessProbe.fsCheckPath }}/.healthcheck{{ end }} && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}

--- a/charts/transmission/tests/statefulset_test.yaml
+++ b/charts/transmission/tests/statefulset_test.yaml
@@ -79,7 +79,7 @@ tests:
           value: RuntimeDefault
 
   # Health probes tests
-  - it: should have liveness probe with exec command and default values
+  - it: should have liveness probe with exec command and default values (runAsUser abc)
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
@@ -89,7 +89,7 @@ tests:
           value: -c
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
-          value: "touch /downloads/.healthcheck && rm --force /downloads/.healthcheck && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null"
+          value: "su -s /bin/sh - abc -c 'touch /downloads/.healthcheck && rm --force /downloads/.healthcheck' && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null"
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
           value: 30
@@ -102,6 +102,15 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 6
+
+  - it: should run liveness probe as root when runAsUser is empty
+    set:
+      livenessProbe:
+        runAsUser: ""
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          value: "touch /downloads/.healthcheck && rm --force /downloads/.healthcheck && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null"
 
   - it: should have readiness probe with default values
     asserts:
@@ -124,9 +133,10 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.failureThreshold
           value: 3
 
-  - it: should allow custom liveness probe values
+  - it: should allow custom liveness probe values with custom runAsUser
     set:
       livenessProbe:
+        runAsUser: "customuser"
         fsCheckPath: /data
         initialDelaySeconds: 60
         periodSeconds: 20
@@ -135,7 +145,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
-          value: "touch /data/.healthcheck && rm --force /data/.healthcheck && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null"
+          value: "su -s /bin/sh - customuser -c 'touch /data/.healthcheck && rm --force /data/.healthcheck' && curl --silent --fail --max-time 5 http://localhost:9091/transmission/web/ >/dev/null"
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
           value: 60

--- a/charts/transmission/values.schema.json
+++ b/charts/transmission/values.schema.json
@@ -301,6 +301,11 @@
       "type": "object",
       "description": "Liveness probe configuration",
       "properties": {
+        "runAsUser": {
+          "type": "string",
+          "description": "User to run filesystem check as (use 'abc' for NFS compatibility with linuxserver images)",
+          "default": "abc"
+        },
         "fsCheckPath": {
           "type": "string",
           "description": "Path to check for write access (detects NFS mount failures)",

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -107,6 +107,8 @@ resources:
 
 # -- Liveness probe configuration
 livenessProbe:
+  # -- User to run filesystem check as (linuxserver images use 'abc')
+  runAsUser: "abc"
   # -- Path to check for write access (detects NFS mount failures)
   fsCheckPath: /downloads
   # -- Initial delay before liveness probe starts


### PR DESCRIPTION
## Summary
- Add `livenessProbe.runAsUser` option (default `abc`) to fix NFS permission issues
- Liveness probe now executes filesystem checks as the configured user instead of root
- Resolves "Permission denied" errors when `/downloads` is mounted via NFS with `root_squash`

## Test plan
- [x] `helm lint` passes
- [x] `check-jsonschema` validation passes  
- [x] `helm unittest` passes (95 tests)
- [x] Template renders correctly with `runAsUser: "abc"` (default)
- [x] Template renders correctly with `runAsUser: ""` (legacy behavior)
- [x] Verified `su` command works in linuxserver/transmission container

Related to #156