### PR TITLE
feat(vipalived): add configurable probes and trackInterface support

### DIFF
--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -1,8 +1,12 @@
 annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update alpine docker tag to v3.23
+    - kind: added
+      description: Add configurable probes with customizable exec commands
+    - kind: added
+      description: Add startupProbe and readinessProbe support
+    - kind: added
+      description: Add trackInterface option for VRRP state management
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +20,7 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.5.2
+version: 0.6.0
 # renovate: datasource=docker depName=alpine
 appVersion: "3.23"
 keywords:

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -1,6 +1,6 @@
 # vipalived
 
-![Version: 0.5.2](https://img.shields.io/badge/Version-0.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.23](https://img.shields.io/badge/AppVersion-3.23-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.23](https://img.shields.io/badge/AppVersion-3.23-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -16,16 +16,16 @@ Keepalived-based VIP management for Kubernetes control plane high availability
 
 ```bash
 # Day 2: Install with default VIP (172.16.101.101/32) on existing cluster
-helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.5.2
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.6.0
 
 # Day 2: Install with custom VIP address
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.5.2 \
+  --version 0.6.0 \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
 
 # Day 1: Generate static pod manifest for cluster bootstrap
 helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.5.2 \
+  --version 0.6.0 \
   --set static=true \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
 ```
@@ -75,7 +75,7 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 
    ```bash
    helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-     --version 0.5.2 \
+     --version 0.6.0 \
      --set static=true \
      --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR \
      --namespace kube-system > vipalived-static-pod.yaml
@@ -138,7 +138,7 @@ All charts published to GHCR are signed using cosign. To verify the chart signat
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/vipalived:0.5.2 \
+  ghcr.io/lexfrei/charts/vipalived:0.6.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -167,10 +167,14 @@ cosign verify \
 | keepalived.vrrpInstance.nopreempt | bool | `true` | Enable non-preemptive mode |
 | keepalived.vrrpInstance.priority | int | `100` | VRRP priority (higher values are preferred) |
 | keepalived.vrrpInstance.state | string | `"BACKUP"` | Initial VRRP state (MASTER or BACKUP) |
+| keepalived.vrrpInstance.trackInterface | list | [] (no tracking) | Interfaces to track for VRRP state transitions. When a tracked interface goes down, keepalived transitions to FAULT state. This is a workaround for https://github.com/acassen/keepalived/issues/1847 |
 | keepalived.vrrpInstance.virtualIpAddress | string | `"172.16.101.101/32"` | Virtual IP address with CIDR notation |
 | keepalived.vrrpInstance.virtualRouterId | int | `51` | Virtual router ID (must be unique in the network) |
 | keepalived.vrrpVersion | int | `3` | VRRP protocol version (2 or 3) |
-| livenessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| livenessProbe | object | `{"enabled":true,"exec":{"command":["pgrep","keepalived"]},"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| livenessProbe.enabled | bool | `true` | Enable liveness probe |
+| livenessProbe.exec | object | `{"command":["pgrep","keepalived"]}` | Exec probe configuration |
+| livenessProbe.exec.command | list | `["pgrep","keepalived"]` | Command to execute for the probe |
 | livenessProbe.failureThreshold | int | `3` | Failure threshold for liveness probe |
 | livenessProbe.initialDelaySeconds | int | `15` | Initial delay before liveness probe starts |
 | livenessProbe.periodSeconds | int | `10` | Period between liveness probe checks |
@@ -182,8 +186,23 @@ cosign verify \
 | podLabels | object | `{}` | Additional labels for pods |
 | podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the pod |
 | priorityClassName | string | `"system-node-critical"` | Priority class name for pod scheduling |
+| readinessProbe | object | `{"enabled":false,"exec":{"command":[]},"failureThreshold":3,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":5}` | Readiness probe configuration |
+| readinessProbe.enabled | bool | `false` | Enable readiness probe |
+| readinessProbe.exec | object | `{"command":[]}` | Exec probe configuration |
+| readinessProbe.exec.command | list | [] (no command, must be set when enabled) | Command to execute for the probe |
+| readinessProbe.failureThreshold | int | `3` | Failure threshold for readiness probe |
+| readinessProbe.periodSeconds | int | `10` | Period between readiness probe checks |
+| readinessProbe.successThreshold | int | `1` | Success threshold for readiness probe |
+| readinessProbe.timeoutSeconds | int | `5` | Timeout for readiness probe |
 | resources | object | `{"limits":{"cpu":"100m","memory":"64Mi"},"requests":{"cpu":"50m","memory":"32Mi"}}` | Resource requests and limits |
 | securityContext | object | `{"capabilities":{"add":["NET_ADMIN","NET_RAW","NET_BROADCAST"]}}` | Security context for the container |
+| startupProbe | object | `{"enabled":false,"exec":{"command":[]},"failureThreshold":12,"periodSeconds":5,"timeoutSeconds":5}` | Startup probe configuration for initial VIP acquisition |
+| startupProbe.enabled | bool | `false` | Enable startup probe |
+| startupProbe.exec | object | `{"command":[]}` | Exec probe configuration |
+| startupProbe.exec.command | list | [] (no command, must be set when enabled) | Command to execute for the probe |
+| startupProbe.failureThreshold | int | `12` | Failure threshold for startup probe |
+| startupProbe.periodSeconds | int | `5` | Period between startup probe checks |
+| startupProbe.timeoutSeconds | int | `5` | Timeout for startup probe |
 | static | bool | `false` | Enable static pod mode for Day 1 cluster bootstrap. When true, renders a Pod manifest instead of DaemonSet with embedded configuration. Use this for pre-CNI VIP availability during initial cluster setup. For Day 2 operations (existing cluster), keep this false (default). |
 | tolerations | list | `[{"key":"CriticalAddonsOnly","operator":"Exists"},{"effect":"NoExecute","key":"node.kubernetes.io/not-ready","operator":"Exists"},{"effect":"NoExecute","key":"node.kubernetes.io/unreachable","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/disk-pressure","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/memory-pressure","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/pid-pressure","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/unschedulable","operator":"Exists"},{"effect":"NoSchedule","key":"node.kubernetes.io/network-unavailable","operator":"Exists"}]` | Tolerations for pod assignment |
 | updateStrategy.maxUnavailable | int | `1` | Maximum number of unavailable pods during update |

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -167,7 +167,7 @@ cosign verify \
 | keepalived.vrrpInstance.nopreempt | bool | `true` | Enable non-preemptive mode |
 | keepalived.vrrpInstance.priority | int | `100` | VRRP priority (higher values are preferred) |
 | keepalived.vrrpInstance.state | string | `"BACKUP"` | Initial VRRP state (MASTER or BACKUP) |
-| keepalived.vrrpInstance.trackInterface | list | [] (no tracking) | Interfaces to track for VRRP state transitions. When a tracked interface goes down, keepalived transitions to FAULT state. This is a workaround for https://github.com/acassen/keepalived/issues/1847 |
+| keepalived.vrrpInstance.trackInterface | list | [] (no tracking) | Interfaces to track for VRRP state transitions. When a tracked interface goes down, keepalived transitions to FAULT state. This is a workaround for keepalived issue 1847. |
 | keepalived.vrrpInstance.virtualIpAddress | string | `"172.16.101.101/32"` | Virtual IP address with CIDR notation |
 | keepalived.vrrpInstance.virtualRouterId | int | `51` | Virtual router ID (must be unique in the network) |
 | keepalived.vrrpVersion | int | `3` | VRRP protocol version (2 or 3) |

--- a/charts/vipalived/templates/_helpers.tpl
+++ b/charts/vipalived/templates/_helpers.tpl
@@ -81,5 +81,12 @@ vrrp_instance {{ .Values.keepalived.vrrpInstance.name }} {
   virtual_ipaddress {
     {{ .Values.keepalived.vrrpInstance.virtualIpAddress }}
   }
+  {{- if .Values.keepalived.vrrpInstance.trackInterface }}
+  track_interface {
+    {{- range .Values.keepalived.vrrpInstance.trackInterface }}
+    {{ . }}
+    {{- end }}
+  }
+  {{- end }}
 }
 {{- end }}

--- a/charts/vipalived/templates/daemonset.yaml
+++ b/charts/vipalived/templates/daemonset.yaml
@@ -67,15 +67,35 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            exec:
+              command:
+                {{- toYaml .Values.startupProbe.exec.command | nindent 16 }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             exec:
               command:
-                - pgrep
-                - keepalived
+                {{- toYaml .Values.livenessProbe.exec.command | nindent 16 }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            exec:
+              command:
+                {{- toYaml .Values.readinessProbe.exec.command | nindent 16 }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/vipalived/templates/pod.yaml
+++ b/charts/vipalived/templates/pod.yaml
@@ -55,15 +55,35 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.startupProbe.enabled }}
+      startupProbe:
+        exec:
+          command:
+            {{- toYaml .Values.startupProbe.exec.command | nindent 12 }}
+        periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+        timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+        failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+      {{- end }}
+      {{- if .Values.livenessProbe.enabled }}
       livenessProbe:
         exec:
           command:
-            - pgrep
-            - keepalived
+            {{- toYaml .Values.livenessProbe.exec.command | nindent 12 }}
         initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
         periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
         timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+      {{- end }}
+      {{- if .Values.readinessProbe.enabled }}
+      readinessProbe:
+        exec:
+          command:
+            {{- toYaml .Values.readinessProbe.exec.command | nindent 12 }}
+        periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+        timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+        failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+        successThreshold: {{ .Values.readinessProbe.successThreshold }}
+      {{- end }}
       {{- with .Values.resources }}
       resources:
         {{- toYaml . | nindent 8 }}

--- a/charts/vipalived/tests/configmap_test.yaml
+++ b/charts/vipalived/tests/configmap_test.yaml
@@ -141,3 +141,51 @@ tests:
       - notMatchRegex:
           path: data["keepalived.conf"]
           pattern: "nopreempt"
+
+  - it: should include track_interface with single interface
+    set:
+      keepalived:
+        vrrpInstance:
+          trackInterface:
+            - eth0
+    asserts:
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "track_interface \\{"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "eth0"
+
+  - it: should include track_interface with multiple interfaces
+    set:
+      keepalived:
+        vrrpInstance:
+          trackInterface:
+            - eth0
+            - eth1
+    asserts:
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "track_interface \\{"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "eth0"
+      - matchRegex:
+          path: data["keepalived.conf"]
+          pattern: "eth1"
+
+  - it: should not include track_interface when empty
+    set:
+      keepalived:
+        vrrpInstance:
+          trackInterface: []
+    asserts:
+      - notMatchRegex:
+          path: data["keepalived.conf"]
+          pattern: "track_interface"
+
+  - it: should not include track_interface when not set
+    asserts:
+      - notMatchRegex:
+          path: data["keepalived.conf"]
+          pattern: "track_interface"

--- a/charts/vipalived/tests/daemonset_test.yaml
+++ b/charts/vipalived/tests/daemonset_test.yaml
@@ -314,6 +314,11 @@ tests:
   - it: should allow custom liveness probe values
     set:
       livenessProbe:
+        enabled: true
+        exec:
+          command:
+            - pgrep
+            - keepalived
         initialDelaySeconds: 30
         periodSeconds: 20
         timeoutSeconds: 10
@@ -335,3 +340,115 @@ tests:
         equal:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 5
+
+  - it: should allow custom liveness probe command
+    set:
+      livenessProbe:
+        enabled: true
+        exec:
+          command:
+            - sh
+            - -c
+            - ip addr show eth0 | grep -q 172.16.101.101
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[0]
+          value: sh
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[1]
+          value: "-c"
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe.exec.command[2]
+          value: "ip addr show eth0 | grep -q 172.16.101.101"
+
+  - it: should disable liveness probe when enabled is false
+    set:
+      livenessProbe:
+        enabled: false
+        exec:
+          command:
+            - pgrep
+            - keepalived
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+    asserts:
+      - template: daemonset.yaml
+        isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should enable startup probe when configured
+    set:
+      startupProbe:
+        enabled: true
+        exec:
+          command:
+            - sh
+            - -c
+            - ip addr show eth0 | grep -q 172.16.101.101
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 12
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command[0]
+          value: sh
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command[1]
+          value: "-c"
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 12
+
+  - it: should not have startup probe by default
+    asserts:
+      - template: daemonset.yaml
+        isNull:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should enable readiness probe when configured
+    set:
+      readinessProbe:
+        enabled: true
+        exec:
+          command:
+            - pgrep
+            - keepalived
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+        successThreshold: 1
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe.exec.command[0]
+          value: pgrep
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 1
+
+  - it: should not have readiness probe by default
+    asserts:
+      - template: daemonset.yaml
+        isNull:
+          path: spec.template.spec.containers[0].readinessProbe

--- a/charts/vipalived/tests/pod_test.yaml
+++ b/charts/vipalived/tests/pod_test.yaml
@@ -233,6 +233,11 @@ tests:
     set:
       static: true
       livenessProbe:
+        enabled: true
+        exec:
+          command:
+            - pgrep
+            - keepalived
         initialDelaySeconds: 30
         periodSeconds: 20
         timeoutSeconds: 10
@@ -244,3 +249,107 @@ tests:
       - equal:
           path: spec.containers[0].livenessProbe.periodSeconds
           value: 20
+
+  - it: should allow custom liveness probe command
+    set:
+      static: true
+      livenessProbe:
+        enabled: true
+        exec:
+          command:
+            - sh
+            - -c
+            - ip addr show eth0 | grep -q 172.16.101.101
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+    asserts:
+      - equal:
+          path: spec.containers[0].livenessProbe.exec.command[0]
+          value: sh
+      - equal:
+          path: spec.containers[0].livenessProbe.exec.command[1]
+          value: "-c"
+      - equal:
+          path: spec.containers[0].livenessProbe.exec.command[2]
+          value: "ip addr show eth0 | grep -q 172.16.101.101"
+
+  - it: should disable liveness probe when enabled is false
+    set:
+      static: true
+      livenessProbe:
+        enabled: false
+        exec:
+          command:
+            - pgrep
+            - keepalived
+        initialDelaySeconds: 15
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+    asserts:
+      - isNull:
+          path: spec.containers[0].livenessProbe
+
+  - it: should enable startup probe when configured
+    set:
+      static: true
+      startupProbe:
+        enabled: true
+        exec:
+          command:
+            - sh
+            - -c
+            - ip addr show eth0 | grep -q 172.16.101.101
+        periodSeconds: 5
+        timeoutSeconds: 5
+        failureThreshold: 12
+    asserts:
+      - equal:
+          path: spec.containers[0].startupProbe.exec.command[0]
+          value: sh
+      - equal:
+          path: spec.containers[0].startupProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.containers[0].startupProbe.failureThreshold
+          value: 12
+
+  - it: should not have startup probe by default
+    set:
+      static: true
+    asserts:
+      - isNull:
+          path: spec.containers[0].startupProbe
+
+  - it: should enable readiness probe when configured
+    set:
+      static: true
+      readinessProbe:
+        enabled: true
+        exec:
+          command:
+            - pgrep
+            - keepalived
+        periodSeconds: 10
+        timeoutSeconds: 5
+        failureThreshold: 3
+        successThreshold: 1
+    asserts:
+      - equal:
+          path: spec.containers[0].readinessProbe.exec.command[0]
+          value: pgrep
+      - equal:
+          path: spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.containers[0].readinessProbe.successThreshold
+          value: 1
+
+  - it: should not have readiness probe by default
+    set:
+      static: true
+    asserts:
+      - isNull:
+          path: spec.containers[0].readinessProbe

--- a/charts/vipalived/values.schema.json
+++ b/charts/vipalived/values.schema.json
@@ -141,6 +141,14 @@
               "type": "string",
               "pattern": "^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$",
               "description": "Virtual IP address with CIDR notation"
+            },
+            "trackInterface": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Interfaces to track for VRRP state transitions. When a tracked interface goes down, keepalived transitions to FAULT state.",
+              "default": []
             }
           },
           "required": ["name", "state", "interface", "priority", "virtualRouterId", "advertInt", "nopreempt", "authentication", "virtualIpAddress"]
@@ -195,10 +203,65 @@
       "type": "object",
       "description": "Security context for the container"
     },
+    "startupProbe": {
+      "type": "object",
+      "description": "Startup probe configuration for initial VIP acquisition",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable startup probe",
+          "default": false
+        },
+        "exec": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Command to execute for the probe"
+            }
+          }
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Period between startup probe checks",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for startup probe",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Failure threshold for startup probe",
+          "minimum": 1
+        }
+      }
+    },
     "livenessProbe": {
       "type": "object",
       "description": "Liveness probe configuration",
       "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable liveness probe",
+          "default": true
+        },
+        "exec": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Command to execute for the probe"
+            }
+          }
+        },
         "initialDelaySeconds": {
           "type": "integer",
           "description": "Initial delay before liveness probe starts",
@@ -219,8 +282,50 @@
           "description": "Failure threshold for liveness probe",
           "minimum": 1
         }
-      },
-      "required": ["initialDelaySeconds", "periodSeconds", "timeoutSeconds", "failureThreshold"]
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "description": "Readiness probe configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable readiness probe",
+          "default": false
+        },
+        "exec": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Command to execute for the probe"
+            }
+          }
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "description": "Period between readiness probe checks",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "Timeout for readiness probe",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "description": "Failure threshold for readiness probe",
+          "minimum": 1
+        },
+        "successThreshold": {
+          "type": "integer",
+          "description": "Success threshold for readiness probe",
+          "minimum": 1
+        }
+      }
     },
     "resources": {
       "type": "object",
@@ -264,7 +369,6 @@
     "image",
     "keepalived",
     "hostNetwork",
-    "priorityClassName",
-    "livenessProbe"
+    "priorityClassName"
   ]
 }

--- a/charts/vipalived/values.yaml
+++ b/charts/vipalived/values.yaml
@@ -71,7 +71,7 @@ keepalived:
 
     # -- Interfaces to track for VRRP state transitions.
     # When a tracked interface goes down, keepalived transitions to FAULT state.
-    # This is a workaround for https://github.com/acassen/keepalived/issues/1847
+    # This is a workaround for keepalived issue 1847.
     # @default -- [] (no tracking)
     trackInterface: []
 

--- a/charts/vipalived/values.yaml
+++ b/charts/vipalived/values.yaml
@@ -69,6 +69,12 @@ keepalived:
     # -- Virtual IP address with CIDR notation
     virtualIpAddress: 172.16.101.101/32
 
+    # -- Interfaces to track for VRRP state transitions.
+    # When a tracked interface goes down, keepalived transitions to FAULT state.
+    # This is a workaround for https://github.com/acassen/keepalived/issues/1847
+    # @default -- [] (no tracking)
+    trackInterface: []
+
 updateStrategy:
   # -- Update strategy type
   type: RollingUpdate
@@ -127,8 +133,32 @@ securityContext:
       - NET_RAW
       - NET_BROADCAST
 
+# -- Startup probe configuration for initial VIP acquisition
+startupProbe:
+  # -- Enable startup probe
+  enabled: false
+  # -- Exec probe configuration
+  exec:
+    # -- Command to execute for the probe
+    # @default -- [] (no command, must be set when enabled)
+    command: []
+  # -- Period between startup probe checks
+  periodSeconds: 5
+  # -- Timeout for startup probe
+  timeoutSeconds: 5
+  # -- Failure threshold for startup probe
+  failureThreshold: 12
+
 # -- Liveness probe configuration
 livenessProbe:
+  # -- Enable liveness probe
+  enabled: true
+  # -- Exec probe configuration
+  exec:
+    # -- Command to execute for the probe
+    command:
+      - pgrep
+      - keepalived
   # -- Initial delay before liveness probe starts
   initialDelaySeconds: 15
   # -- Period between liveness probe checks
@@ -137,6 +167,24 @@ livenessProbe:
   timeoutSeconds: 5
   # -- Failure threshold for liveness probe
   failureThreshold: 3
+
+# -- Readiness probe configuration
+readinessProbe:
+  # -- Enable readiness probe
+  enabled: false
+  # -- Exec probe configuration
+  exec:
+    # -- Command to execute for the probe
+    # @default -- [] (no command, must be set when enabled)
+    command: []
+  # -- Period between readiness probe checks
+  periodSeconds: 10
+  # -- Timeout for readiness probe
+  timeoutSeconds: 5
+  # -- Failure threshold for readiness probe
+  failureThreshold: 3
+  # -- Success threshold for readiness probe
+  successThreshold: 1
 
 # -- Resource requests and limits
 resources:


### PR DESCRIPTION
# Pull Request

## Description

Add fully customizable probe configuration and trackInterface option for the vipalived chart.

**Key features:**
- Configurable `livenessProbe.exec.command` (default: `pgrep keepalived`, overridable)
- New `startupProbe` support for initial VIP acquisition scenarios
- New `readinessProbe` support
- `enabled` flag for all probes (livenessProbe enabled by default)
- `trackInterface` option as workaround for keepalived interface recreation bug

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [ ] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior

## Additional context

Closes #160

This implementation follows TDD approach with 12 new tests added (96 total).

**Backward compatible:** Existing configurations work without changes. Default livenessProbe behavior is preserved (`pgrep keepalived`).

**Related upstream fix:** https://github.com/acassen/keepalived/pull/2681