### PR TITLE
feat(transmission): add terminationGracePeriodSeconds option

### DIFF
--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
     - kind: added
-      description: "Add livenessProbe.runAsUser option (default 'abc') to fix NFS permission issues"
+      description: "Add terminationGracePeriodSeconds option for graceful pod shutdown"
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +16,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.6.0"
+version: "1.7.0"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.0.6"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.0.6](https://img.shields.io/badge/AppVersion-4.0.6-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.6.0
+  --version 1.7.0
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.6.0 \
+  --version 1.7.0 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.6.0 \
+  ghcr.io/lexfrei/charts/transmission:1.7.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -140,6 +140,7 @@ helm delete transmission
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use |
+| terminationGracePeriodSeconds | string | Kubernetes default (30 seconds) | Duration in seconds the pod needs to terminate gracefully |
 | tolerations | list | `[]` |  |
 | updateStrategy | object | `{"type":"RollingUpdate"}` | Update strategy |
 

--- a/charts/transmission/templates/statefulset.yaml
+++ b/charts/transmission/templates/statefulset.yaml
@@ -27,6 +27,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "transmission.serviceAccountName" . }}
+      {{- if not (kindIs "invalid" .Values.terminationGracePeriodSeconds) }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- with .Values.initContainers }}

--- a/charts/transmission/tests/statefulset_test.yaml
+++ b/charts/transmission/tests/statefulset_test.yaml
@@ -436,3 +436,25 @@ tests:
             name: gluetun-config
             secret:
               secretName: gluetun-config
+
+  # terminationGracePeriodSeconds tests
+  - it: should not set terminationGracePeriodSeconds by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.terminationGracePeriodSeconds
+
+  - it: should set terminationGracePeriodSeconds when specified
+    set:
+      terminationGracePeriodSeconds: 120
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 120
+
+  - it: should allow terminationGracePeriodSeconds to be 0
+    set:
+      terminationGracePeriodSeconds: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 0

--- a/charts/transmission/values.schema.json
+++ b/charts/transmission/values.schema.json
@@ -359,6 +359,11 @@
         }
       }
     },
+    "terminationGracePeriodSeconds": {
+      "type": ["integer", "null"],
+      "description": "Duration in seconds the pod needs to terminate gracefully",
+      "minimum": 0
+    },
     "persistence": {
       "type": "object",
       "properties": {

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -131,6 +131,10 @@ readinessProbe:
   # -- Failure threshold for readiness probe
   failureThreshold: 3
 
+# -- Duration in seconds the pod needs to terminate gracefully
+# @default -- Kubernetes default (30 seconds)
+terminationGracePeriodSeconds:
+
 # -- Persistence configuration
 persistence:
   # -- Config volume configuration


### PR DESCRIPTION
# Pull Request

## Description

Add configurable `terminationGracePeriodSeconds` option for graceful pod shutdown. When not specified, uses Kubernetes default (30 seconds).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [ ] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior

## Additional context

TDD approach: tests written first, then implementation.