### PR TITLE
fix(ci): add automatic version bump to renovate-update workflow

### DIFF
--- a/.github/workflows/renovate-update.yaml
+++ b/.github/workflows/renovate-update.yaml
@@ -84,6 +84,12 @@ jobs:
 
             echo "✅ Updated Chart.yaml changelog"
 
+            # Bump patch version to trigger new release
+            current_version=$(yq eval '.version' "$chart_file")
+            new_version=$(echo "$current_version" | awk -F. '{print $1"."$2"."$3+1}')
+            yq eval -i ".version = \"$new_version\"" "$chart_file"
+            echo "✅ Bumped version: $current_version -> $new_version"
+
             # Generate documentation if README.md.gotmpl exists
             if [ -f "$chart_dir/README.md.gotmpl" ]; then
               echo "📚 Generating documentation for $chart_dir"

--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Creation of a cloudflared deployment - a reverse tunnel for an environment
 type: application
-version: "0.15.1"
+version: "0.15.2"
 kubeVersion: ">=1.21.0-0"
 # renovate: datasource=docker depName=cloudflare/cloudflared
 appVersion: "2026.1.2"

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.2](https://img.shields.io/badge/AppVersion-2026.1.2-informational?style=flat-square)
+![Version: 0.15.2](https://img.shields.io/badge/Version-0.15.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.2](https://img.shields.io/badge/AppVersion-2026.1.2-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -69,7 +69,7 @@ Before installing the chart, create a tunnel in Cloudflare:
 # Install with inline configuration
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.15.1 \
+  --version 0.15.2 \
   --set cloudflare.account=YOUR_ACCOUNT_ID \
   --set cloudflare.tunnelName=YOUR_TUNNEL_NAME \
   --set cloudflare.tunnelId=YOUR_TUNNEL_ID \
@@ -80,7 +80,7 @@ helm install cloudflare-tunnel \
 # Install with values file
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.15.1 \
+  --version 0.15.2 \
   --values values.yaml
 ```
 
@@ -90,7 +90,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.15.1 \
+  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.15.2 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/system-upgrade-controller/Chart.yaml
+++ b/charts/system-upgrade-controller/Chart.yaml
@@ -22,7 +22,7 @@ apiVersion: v2
 name: system-upgrade-controller
 description: Kubernetes-native upgrade controller for nodes using declarative Plans
 type: application
-version: "0.2.1"
+version: "0.2.2"
 # renovate: datasource=github-releases depName=rancher/system-upgrade-controller
 appVersion: "v0.18.0"
 icon: https://avatars.githubusercontent.com/u/9343010

--- a/charts/system-upgrade-controller/README.md
+++ b/charts/system-upgrade-controller/README.md
@@ -1,6 +1,6 @@
 # system-upgrade-controller
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.7.0"
+version: "1.7.1"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.1.0"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
+![Version: 1.7.1](https://img.shields.io/badge/Version-1.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.0](https://img.shields.io/badge/AppVersion-4.1.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.7.0
+  --version 1.7.1
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.7.0 \
+  --version 1.7.1 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.7.0 \
+  ghcr.io/lexfrei/charts/transmission:1.7.1 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```


### PR DESCRIPTION
## Summary
- Add automatic patch version bump to `renovate-update.yaml` workflow when Renovate updates dependencies
- Bump chart versions for pending Renovate updates that were skipped

## Problem
Renovate PRs were updating `appVersion` and dependencies but not incrementing chart `version`. 
The publish workflow checks if release tag exists, so all updates after last manual releases were skipped.

**Affected charts:**
- transmission: 1.7.0 → 1.7.1 (appVersion 4.1.0)
- cloudflare-tunnel: 0.15.1 → 0.15.2 (appVersion 2026.1.2)
- system-upgrade-controller: 0.2.1 → 0.2.2 (kubectl v1.35.0)

## Changes
1. `renovate-update.yaml`: Now bumps patch version after updating changelog annotation
2. Manual version bumps for all affected charts to trigger releases

## Test plan
- [ ] Verify workflow syntax is correct
- [ ] After merge, verify publish workflow creates releases for all three charts
- [ ] Test future Renovate PR to confirm version bump works automatically