### PR TITLE
feat(extractedprism): add Helm chart for per-node API server load balancer

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,7 @@ jobs:
         chart:
           - charts/cloudflare-tunnel
           - charts/eclipse-edc
+          - charts/extractedprism
           - charts/me-site
           - charts/system-upgrade-controller
           - charts/transmission
@@ -62,6 +63,7 @@ jobs:
         chart:
           - charts/cloudflare-tunnel
           - charts/eclipse-edc
+          - charts/extractedprism
           - charts/me-site
           - charts/system-upgrade-controller
           - charts/transmission

--- a/charts/extractedprism/Chart.yaml
+++ b/charts/extractedprism/Chart.yaml
@@ -1,0 +1,31 @@
+annotations:
+  artifacthub.io/category: networking
+  artifacthub.io/changes: |-
+    - kind: added
+      description: Initial chart release with DaemonSet, RBAC, and health probes
+  artifacthub.io/license: BSD-3-Clause
+  artifacthub.io/links: |
+    - name: Chart Repository
+      url: https://github.com/lexfrei/charts/
+    - name: Source Code
+      url: https://github.com/lexfrei/extractedprism/
+  artifacthub.io/signKey: |
+    fingerprint: keyless
+    url: https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master
+apiVersion: v2
+name: extractedprism
+description: Per-node TCP load balancer for Kubernetes API server high availability
+type: application
+version: 0.1.0
+# renovate: datasource=github-releases depName=lexfrei/extractedprism
+appVersion: "0.0.0"
+keywords:
+  - load-balancer
+  - control-plane
+  - high-availability
+  - tcp-proxy
+  - api-server
+maintainers:
+  - name: lexfrei
+    email: f@lex.la
+kubeVersion: '>=1.26.0-0'

--- a/charts/extractedprism/Chart.yaml
+++ b/charts/extractedprism/Chart.yaml
@@ -13,6 +13,7 @@ annotations:
     fingerprint: keyless
     url: https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master
 apiVersion: v2
+home: https://github.com/lexfrei/charts/
 name: extractedprism
 description: Per-node TCP load balancer for Kubernetes API server high availability
 type: application

--- a/charts/extractedprism/README.md
+++ b/charts/extractedprism/README.md
@@ -1,0 +1,127 @@
+# extractedprism
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+
+## Status
+
+[![Lint and Test](https://github.com/lexfrei/charts/actions/workflows/test.yaml/badge.svg)](https://github.com/lexfrei/charts/actions/workflows/test.yaml)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/extractedprism)](https://artifacthub.io/packages/helm/extractedprism/extractedprism)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
+
+Per-node TCP load balancer for Kubernetes API server high availability
+
+## Overview
+
+extractedprism is a per-node TCP load balancer for Kubernetes API server high availability, inspired by [Talos KubePrism](https://www.talos.dev/latest/kubernetes-guides/configuration/kubeprism/). It runs as a DaemonSet on every node, proxying `localhost:7445` to healthy API server endpoints.
+
+**Key features:**
+
+- **No VIP dependency**: Each node connects to localhost, eliminating VRRP/keepalived single points of failure
+- **Two-level discovery**: Static bootstrap endpoints + dynamic Kubernetes EndpointSlice Watch
+- **CNI-independent bootstrap**: Uses hostNetwork and static endpoints, works before CNI starts
+- **Health-checked upstream**: Only routes to healthy API servers
+
+## TL;DR
+
+```bash
+helm install extractedprism oci://ghcr.io/lexfrei/charts/extractedprism \
+  --version 0.1.0 \
+  --set endpoints="10.0.0.1:6443,10.0.0.2:6443,10.0.0.3:6443"
+```
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+```bash
+helm install extractedprism oci://ghcr.io/lexfrei/charts/extractedprism \
+  --set endpoints="CP1_IP:6443,CP2_IP:6443,CP3_IP:6443"
+```
+
+The `endpoints` value is required and should list all control plane node IPs with the API server port.
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall extractedprism
+```
+
+## Verifying Chart Signature
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/extractedprism:0.1.0 \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod assignment |
+| bindAddress | string | `"127.0.0.1"` | Address to bind the TCP load balancer listener |
+| bindPort | int | `7445` | Port for the TCP load balancer listener |
+| dnsPolicy | string | `"ClusterFirstWithHostNet"` | DNS policy (ClusterFirstWithHostNet required when hostNetwork is true) |
+| enableDiscovery | bool | `true` | Enable Kubernetes endpoint discovery (watches EndpointSlice API). When true, dynamically discovers API server endpoints in addition to static ones. |
+| endpoints | string | `""` | Comma-separated list of control plane endpoints (host:port). Required. These are the static bootstrap endpoints used before Kubernetes API discovery is available (e.g., before CNI starts). |
+| fullnameOverride | string | `""` | Override the full name of the chart |
+| healthInterval | string | `"20s"` | Interval between upstream health checks |
+| healthPort | int | `7446` | Port for the HTTP health check server |
+| healthTimeout | string | `"15s"` | Timeout for each upstream health check |
+| hostNetwork | bool | `true` | Enable host network mode (required for localhost LB access from kubelet) |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"ghcr.io/lexfrei/extractedprism"` | Container image repository |
+| image.tag | string | `""` | Container image tag (defaults to chart appVersion if not set) |
+| imagePullSecrets | list | `[]` | Image pull secrets for private registries |
+| livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/healthz","port":7446},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| logLevel | string | `"info"` | Log level (debug, info, warn, error) |
+| nameOverride | string | `""` | Override the name of the chart |
+| nodeSelector | object | `{}` | Node selector for pod assignment |
+| podAnnotations | object | `{}` | Annotations for pods |
+| podLabels | object | `{}` | Additional labels for pods |
+| podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the pod |
+| priorityClassName | string | `"system-node-critical"` | Priority class name for pod scheduling |
+| readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/readyz","port":7446},"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe configuration |
+| resources | object | `{"limits":{"cpu":"100m","memory":"64Mi"},"requests":{"cpu":"10m","memory":"16Mi"}}` | Resource requests and limits |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":65534}` | Security context for the container |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the ServiceAccount |
+| serviceAccount.create | bool | `true` | Create a ServiceAccount for extractedprism |
+| serviceAccount.name | string | `""` | Name of the ServiceAccount (defaults to chart fullname) |
+| tolerations | list | `[{"operator":"Exists"}]` | Tolerations for pod assignment. Uses catch-all toleration by default because extractedprism is critical infrastructure that MUST run on every node regardless of any taints. |
+| updateStrategy.maxUnavailable | int | `1` | Maximum number of unavailable pods during update |
+| updateStrategy.type | string | `"RollingUpdate"` | Update strategy type |
+
+## Architecture
+
+extractedprism runs as a DaemonSet with `hostNetwork: true` on every node. Each pod:
+
+1. Starts a TCP load balancer on `127.0.0.1:7445`
+2. Loads static endpoints from `--endpoints` flag (available immediately at boot)
+3. Optionally watches Kubernetes EndpointSlice API for dynamic API server discovery
+4. Health-checks all upstreams and routes only to healthy ones
+5. Exposes `/healthz` (liveness) and `/readyz` (readiness) on port 7446
+
+Configure kubelet on each node to use `https://127.0.0.1:7445` as the API server address.
+
+## Important Notes
+
+- **Host Network**: Required for localhost access from kubelet and other host-level processes
+- **Priority Class**: Uses `system-node-critical` to ensure scheduling under resource pressure
+- **Security**: Runs as non-root (UID 65534) with read-only filesystem and all capabilities dropped
+- **No NET_ADMIN**: Unlike keepalived/VIP solutions, extractedprism needs no special network capabilities
+
+## Links
+
+- [Source Code](https://github.com/lexfrei/extractedprism/)
+- [Chart Repository](https://github.com/lexfrei/charts/)
+- [Talos KubePrism (inspiration)](https://www.talos.dev/latest/kubernetes-guides/configuration/kubeprism/)
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| lexfrei | <f@lex.la> |  |

--- a/charts/extractedprism/README.md.gotmpl
+++ b/charts/extractedprism/README.md.gotmpl
@@ -1,0 +1,88 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.badgesSection" . }}
+
+## Status
+
+[![Lint and Test](https://github.com/lexfrei/charts/actions/workflows/test.yaml/badge.svg)](https://github.com/lexfrei/charts/actions/workflows/test.yaml)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/extractedprism)](https://artifacthub.io/packages/helm/extractedprism/extractedprism)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
+
+{{ template "chart.description" . }}
+
+## Overview
+
+extractedprism is a per-node TCP load balancer for Kubernetes API server high availability, inspired by [Talos KubePrism](https://www.talos.dev/latest/kubernetes-guides/configuration/kubeprism/). It runs as a DaemonSet on every node, proxying `localhost:7445` to healthy API server endpoints.
+
+**Key features:**
+
+- **No VIP dependency**: Each node connects to localhost, eliminating VRRP/keepalived single points of failure
+- **Two-level discovery**: Static bootstrap endpoints + dynamic Kubernetes EndpointSlice Watch
+- **CNI-independent bootstrap**: Uses hostNetwork and static endpoints, works before CNI starts
+- **Health-checked upstream**: Only routes to healthy API servers
+
+## TL;DR
+
+```bash
+helm install extractedprism oci://ghcr.io/lexfrei/charts/extractedprism \
+  --version {{ template "chart.version" . }} \
+  --set endpoints="10.0.0.1:6443,10.0.0.2:6443,10.0.0.3:6443"
+```
+
+## Prerequisites
+
+- Kubernetes 1.26+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+```bash
+helm install extractedprism oci://ghcr.io/lexfrei/charts/extractedprism \
+  --set endpoints="CP1_IP:6443,CP2_IP:6443,CP3_IP:6443"
+```
+
+The `endpoints` value is required and should list all control plane node IPs with the API server port.
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall extractedprism
+```
+
+## Verifying Chart Signature
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/extractedprism:{{ template "chart.version" . }} \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+{{ template "chart.valuesSection" . }}
+
+## Architecture
+
+extractedprism runs as a DaemonSet with `hostNetwork: true` on every node. Each pod:
+
+1. Starts a TCP load balancer on `127.0.0.1:7445`
+2. Loads static endpoints from `--endpoints` flag (available immediately at boot)
+3. Optionally watches Kubernetes EndpointSlice API for dynamic API server discovery
+4. Health-checks all upstreams and routes only to healthy ones
+5. Exposes `/healthz` (liveness) and `/readyz` (readiness) on port 7446
+
+Configure kubelet on each node to use `https://127.0.0.1:7445` as the API server address.
+
+## Important Notes
+
+- **Host Network**: Required for localhost access from kubelet and other host-level processes
+- **Priority Class**: Uses `system-node-critical` to ensure scheduling under resource pressure
+- **Security**: Runs as non-root (UID 65534) with read-only filesystem and all capabilities dropped
+- **No NET_ADMIN**: Unlike keepalived/VIP solutions, extractedprism needs no special network capabilities
+
+## Links
+
+- [Source Code](https://github.com/lexfrei/extractedprism/)
+- [Chart Repository](https://github.com/lexfrei/charts/)
+- [Talos KubePrism (inspiration)](https://www.talos.dev/latest/kubernetes-guides/configuration/kubeprism/)
+
+{{ template "chart.maintainersSection" . }}

--- a/charts/extractedprism/templates/_helpers.tpl
+++ b/charts/extractedprism/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "extractedprism.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "extractedprism.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "extractedprism.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "extractedprism.labels" -}}
+helm.sh/chart: {{ include "extractedprism.chart" . }}
+{{ include "extractedprism.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "extractedprism.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "extractedprism.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "extractedprism.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "extractedprism.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/extractedprism/templates/clusterrole.yaml
+++ b/charts/extractedprism/templates/clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "extractedprism.fullname" . }}
+  labels:
+    {{- include "extractedprism.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/charts/extractedprism/templates/clusterrolebinding.yaml
+++ b/charts/extractedprism/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "extractedprism.fullname" . }}
+  labels:
+    {{- include "extractedprism.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "extractedprism.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "extractedprism.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/extractedprism/templates/daemonset.yaml
+++ b/charts/extractedprism/templates/daemonset.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "extractedprism.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "extractedprism.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "extractedprism.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: {{ .Values.updateStrategy.type }}
+    {{- if eq .Values.updateStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.updateStrategy.maxUnavailable }}
+    {{- end }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "extractedprism.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      hostNetwork: {{ .Values.hostNetwork }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "extractedprism.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: extractedprism
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--endpoints"
+            - {{ .Values.endpoints | quote }}
+            - "--bind-address"
+            - {{ .Values.bindAddress | quote }}
+            - "--bind-port"
+            - {{ .Values.bindPort | quote }}
+            - "--health-port"
+            - {{ .Values.healthPort | quote }}
+            - "--health-interval"
+            - {{ .Values.healthInterval | quote }}
+            - "--health-timeout"
+            - {{ .Values.healthTimeout | quote }}
+            - "--enable-discovery={{ .Values.enableDiscovery }}"
+            - "--log-level"
+            - {{ .Values.logLevel | quote }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/extractedprism/templates/serviceaccount.yaml
+++ b/charts/extractedprism/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "extractedprism.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "extractedprism.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/extractedprism/tests/daemonset_test.yaml
+++ b/charts/extractedprism/tests/daemonset_test.yaml
@@ -1,0 +1,303 @@
+suite: test daemonset
+templates:
+  - daemonset.yaml
+tests:
+  - it: should create a DaemonSet with default values
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-extractedprism
+      - matchRegex:
+          path: metadata.labels["app.kubernetes.io/name"]
+          pattern: extractedprism
+      - matchRegex:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          pattern: RELEASE-NAME
+
+  - it: should have correct selector labels
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: extractedprism
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: RELEASE-NAME
+
+  - it: should use RollingUpdate strategy by default
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.updateStrategy.rollingUpdate.maxUnavailable
+          value: 1
+
+  - it: should support OnDelete update strategy
+    set:
+      updateStrategy:
+        type: OnDelete
+    asserts:
+      - equal:
+          path: spec.updateStrategy.type
+          value: OnDelete
+      - isNull:
+          path: spec.updateStrategy.rollingUpdate
+
+  - it: should enable hostNetwork by default
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+
+  - it: should set dnsPolicy to ClusterFirstWithHostNet by default
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+
+  - it: should set priorityClassName to system-node-critical
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-node-critical
+
+  - it: should have catch-all toleration by default
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.tolerations
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            operator: Exists
+
+  - it: should configure container with correct image
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: extractedprism
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr.io/lexfrei/extractedprism:.+$
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should use custom image tag when provided
+    set:
+      image:
+        tag: "1.2.3"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/lexfrei/extractedprism:1.2.3"
+
+  - it: should pass endpoints as args
+    set:
+      endpoints: "10.0.0.1:6443,10.0.0.2:6443"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--endpoints"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "10.0.0.1:6443,10.0.0.2:6443"
+
+  - it: should pass all configuration flags as args
+    set:
+      endpoints: "10.0.0.1:6443"
+      bindAddress: "0.0.0.0"
+      bindPort: 8445
+      healthPort: 8446
+      healthInterval: "30s"
+      healthTimeout: "10s"
+      enableDiscovery: false
+      logLevel: "debug"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--bind-address"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "0.0.0.0"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--bind-port"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "8445"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--health-port"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "8446"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--health-interval"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "30s"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--health-timeout"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "10s"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--enable-discovery=false"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--log-level"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "debug"
+
+  - it: should have readiness probe on /readyz
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 7446
+
+  - it: should have liveness probe on /healthz
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 7446
+
+  - it: should set resource limits and requests
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 64Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 16Mi
+
+  - it: should set security context for non-root read-only container
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should set pod security context
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: should use service account
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-extractedprism
+
+  - it: should support custom podAnnotations
+    set:
+      podAnnotations:
+        custom/annotation: test-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["custom/annotation"]
+          value: test-value
+
+  - it: should support custom podLabels
+    set:
+      podLabels:
+        custom-label: test-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["custom-label"]
+          value: test-value
+
+  - it: should support custom namespace via release
+    release:
+      namespace: custom-namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: custom-namespace
+
+  - it: should support imagePullSecrets
+    set:
+      imagePullSecrets:
+        - name: my-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.imagePullSecrets
+          content:
+            name: my-secret
+
+  - it: should support custom affinity
+    set:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: custom-key
+                    operator: In
+                    values:
+                      - custom-value
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.affinity
+
+  - it: should support custom nodeSelector
+    set:
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["node-role.kubernetes.io/control-plane"]
+          value: "true"
+
+  - it: should use fullnameOverride when provided
+    set:
+      fullnameOverride: custom-name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-name
+
+  - it: should support custom resources
+    set:
+      resources:
+        limits:
+          cpu: 200m
+          memory: 128Mi
+        requests:
+          cpu: 50m
+          memory: 32Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi

--- a/charts/extractedprism/tests/edge_cases_test.yaml
+++ b/charts/extractedprism/tests/edge_cases_test.yaml
@@ -1,0 +1,75 @@
+suite: test edge cases
+templates:
+  - daemonset.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+tests:
+  - it: should render all resources together
+    asserts:
+      - template: daemonset.yaml
+        hasDocuments:
+          count: 1
+      - template: serviceaccount.yaml
+        hasDocuments:
+          count: 1
+      - template: clusterrole.yaml
+        hasDocuments:
+          count: 1
+      - template: clusterrolebinding.yaml
+        hasDocuments:
+          count: 1
+
+  - it: should not have nodeSelector by default
+    template: daemonset.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.nodeSelector
+
+  - it: should disable hostNetwork when set to false
+    template: daemonset.yaml
+    set:
+      hostNetwork: false
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+
+  - it: should support empty tolerations
+    template: daemonset.yaml
+    set:
+      tolerations: []
+    asserts:
+      - isNull:
+          path: spec.template.spec.tolerations
+
+  - it: should propagate labels to all resources
+    template: daemonset.yaml
+    asserts:
+      - isNotNull:
+          path: metadata.labels["helm.sh/chart"]
+      - isNotNull:
+          path: metadata.labels["app.kubernetes.io/version"]
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm
+
+  - it: should use nameOverride correctly
+    template: daemonset.yaml
+    set:
+      nameOverride: short-name
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-short-name
+
+  - it: should reference correct service account in ClusterRoleBinding with custom name
+    template: clusterrolebinding.yaml
+    set:
+      serviceAccount:
+        create: true
+        name: custom-sa
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: custom-sa

--- a/charts/extractedprism/tests/rbac_test.yaml
+++ b/charts/extractedprism/tests/rbac_test.yaml
@@ -1,0 +1,84 @@
+suite: test rbac
+templates:
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+tests:
+  - it: should create ServiceAccount by default
+    template: serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-extractedprism
+
+  - it: should not create ServiceAccount when disabled
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should support custom ServiceAccount name
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        create: true
+        name: custom-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: custom-sa
+
+  - it: should support ServiceAccount annotations
+    template: serviceaccount.yaml
+    set:
+      serviceAccount:
+        create: true
+        annotations:
+          eks.amazonaws.com/role-arn: arn:aws:iam::role/test
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: "arn:aws:iam::role/test"
+
+  - it: should create ClusterRole with endpoint discovery permissions
+    template: clusterrole.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - discovery.k8s.io
+            resources:
+              - endpointslices
+            verbs:
+              - get
+              - list
+              - watch
+
+  - it: should create ClusterRoleBinding
+    template: clusterrolebinding.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: RELEASE-NAME-extractedprism

--- a/charts/extractedprism/values.schema.json
+++ b/charts/extractedprism/values.schema.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the full name of the chart"
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Image pull policy"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Container image tag"
+        }
+      },
+      "required": ["repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Image pull secrets for private registries"
+    },
+    "endpoints": {
+      "type": "string",
+      "description": "Comma-separated list of control plane endpoints (host:port)"
+    },
+    "bindAddress": {
+      "type": "string",
+      "description": "Address to bind the TCP load balancer listener"
+    },
+    "bindPort": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "Port for the TCP load balancer listener"
+    },
+    "healthPort": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "Port for the HTTP health check server"
+    },
+    "healthInterval": {
+      "type": "string",
+      "pattern": "^[0-9]+(s|m|h)$",
+      "description": "Interval between upstream health checks"
+    },
+    "healthTimeout": {
+      "type": "string",
+      "pattern": "^[0-9]+(s|m|h)$",
+      "description": "Timeout for each upstream health check"
+    },
+    "enableDiscovery": {
+      "type": "boolean",
+      "description": "Enable Kubernetes endpoint discovery"
+    },
+    "logLevel": {
+      "type": "string",
+      "enum": ["debug", "info", "warn", "error"],
+      "description": "Log level"
+    },
+    "updateStrategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["RollingUpdate", "OnDelete"],
+          "description": "Update strategy type"
+        },
+        "maxUnavailable": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum number of unavailable pods during update"
+        }
+      },
+      "required": ["type"]
+    },
+    "hostNetwork": {
+      "type": "boolean",
+      "description": "Enable host network mode"
+    },
+    "dnsPolicy": {
+      "type": "string",
+      "enum": ["ClusterFirst", "ClusterFirstWithHostNet", "Default", "None"],
+      "description": "DNS policy for pods"
+    },
+    "priorityClassName": {
+      "type": "string",
+      "description": "Priority class name for pod scheduling"
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector for pod assignment"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Tolerations for pod assignment"
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules for pod assignment"
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the pod"
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context for the container"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Create a ServiceAccount"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the ServiceAccount"
+        },
+        "annotations": {
+          "type": "object",
+          "description": "Annotations for the ServiceAccount"
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "description": "Readiness probe configuration"
+    },
+    "livenessProbe": {
+      "type": "object",
+      "description": "Liveness probe configuration"
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "limits": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        },
+        "requests": {
+          "type": "object",
+          "properties": {
+            "cpu": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "description": "Resource requests and limits"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Additional labels for pods"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "description": "Annotations for pods"
+    }
+  },
+  "required": [
+    "image",
+    "hostNetwork",
+    "priorityClassName",
+    "bindPort",
+    "healthPort"
+  ]
+}

--- a/charts/extractedprism/values.yaml
+++ b/charts/extractedprism/values.yaml
@@ -1,0 +1,132 @@
+# Default values for extractedprism.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Override the name of the chart
+nameOverride: ""
+
+# -- Override the full name of the chart
+fullnameOverride: ""
+
+image:
+  # -- Container image repository
+  repository: ghcr.io/lexfrei/extractedprism
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+  # -- Container image tag (defaults to chart appVersion if not set)
+  tag: ""
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# -- Comma-separated list of control plane endpoints (host:port).
+# Required. These are the static bootstrap endpoints used before Kubernetes
+# API discovery is available (e.g., before CNI starts).
+endpoints: ""
+
+# -- Address to bind the TCP load balancer listener
+bindAddress: "127.0.0.1"
+
+# -- Port for the TCP load balancer listener
+bindPort: 7445
+
+# -- Port for the HTTP health check server
+healthPort: 7446
+
+# -- Interval between upstream health checks
+healthInterval: "20s"
+
+# -- Timeout for each upstream health check
+healthTimeout: "15s"
+
+# -- Enable Kubernetes endpoint discovery (watches EndpointSlice API).
+# When true, dynamically discovers API server endpoints in addition to static ones.
+enableDiscovery: true
+
+# -- Log level (debug, info, warn, error)
+logLevel: "info"
+
+updateStrategy:
+  # -- Update strategy type
+  type: RollingUpdate
+  # -- Maximum number of unavailable pods during update
+  maxUnavailable: 1
+
+# -- Enable host network mode (required for localhost LB access from kubelet)
+hostNetwork: true
+
+# -- DNS policy (ClusterFirstWithHostNet required when hostNetwork is true)
+dnsPolicy: ClusterFirstWithHostNet
+
+# -- Priority class name for pod scheduling
+priorityClassName: system-node-critical
+
+# -- Node selector for pod assignment
+nodeSelector: {}
+
+# -- Tolerations for pod assignment.
+# Uses catch-all toleration by default because extractedprism is critical
+# infrastructure that MUST run on every node regardless of any taints.
+tolerations:
+  - operator: Exists
+
+# -- Affinity rules for pod assignment
+affinity: {}
+
+# -- Security context for the pod
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Security context for the container
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+serviceAccount:
+  # -- Create a ServiceAccount for extractedprism
+  create: true
+  # -- Name of the ServiceAccount (defaults to chart fullname)
+  name: ""
+  # -- Annotations to add to the ServiceAccount
+  annotations: {}
+
+# -- Readiness probe configuration
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: 7446
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- Liveness probe configuration
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 7446
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- Resource requests and limits
+resources:
+  limits:
+    cpu: 100m
+    memory: 64Mi
+  requests:
+    cpu: 10m
+    memory: 16Mi
+
+# -- Additional labels for pods
+podLabels: {}
+
+# -- Annotations for pods
+podAnnotations: {}


### PR DESCRIPTION
# Pull Request

## Description

Add new Helm chart for extractedprism — per-node TCP load balancer for Kubernetes API
server high availability. Each node runs a localhost LB on port 7445, proxying to healthy
API server endpoints. Eliminates VIP/VRRP dependency for control plane HA.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/extractedprism`)
- [x] Schema validation passes (`check-jsonschema`)
- [x] Helm lint passes (`helm lint charts/extractedprism`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

## Additional context

- 39 helm-unittest tests across 3 suites (DaemonSet, RBAC, edge cases)
- TDD approach: tests written first, then templates implemented
- appVersion 0.0.0 placeholder — Renovate will update from github-releases