### PR TITLE
feat(extractedprism): make RBAC conditional on enableDiscovery

### DIFF
--- a/charts/extractedprism/Chart.yaml
+++ b/charts/extractedprism/Chart.yaml
@@ -1,8 +1,8 @@
 annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
-    - kind: added
-      description: Add Artifact Hub repository metadata
+    - kind: changed
+      description: Make RBAC resources conditional on enableDiscovery
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -17,7 +17,7 @@ home: https://github.com/lexfrei/charts/
 name: extractedprism
 description: Per-node TCP load balancer for Kubernetes API server high availability
 type: application
-version: 0.1.3
+version: 0.1.4
 # renovate: datasource=github-releases depName=lexfrei/extractedprism
 appVersion: "v0.2.0"
 keywords:

--- a/charts/extractedprism/README.md
+++ b/charts/extractedprism/README.md
@@ -1,6 +1,6 @@
 # extractedprism
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 ## Status
 
@@ -25,7 +25,7 @@ extractedprism is a per-node TCP load balancer for Kubernetes API server high av
 
 ```bash
 helm install extractedprism oci://ghcr.io/lexfrei/charts/extractedprism \
-  --version 0.1.3 \
+  --version 0.1.4 \
   --set endpoints="10.0.0.1:6443,10.0.0.2:6443,10.0.0.3:6443"
 ```
 
@@ -53,7 +53,7 @@ helm uninstall extractedprism
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/extractedprism:0.1.3 \
+  ghcr.io/lexfrei/charts/extractedprism:0.1.4 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/extractedprism/templates/clusterrole.yaml
+++ b/charts/extractedprism/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableDiscovery }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -13,3 +14,4 @@ rules:
   - get
   - list
   - watch
+{{- end }}

--- a/charts/extractedprism/templates/clusterrolebinding.yaml
+++ b/charts/extractedprism/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enableDiscovery }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "extractedprism.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/extractedprism/tests/edge_cases_test.yaml
+++ b/charts/extractedprism/tests/edge_cases_test.yaml
@@ -63,6 +63,23 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-short-name
 
+  - it: should render only daemonset and serviceaccount when discovery disabled
+    set:
+      enableDiscovery: false
+    asserts:
+      - template: daemonset.yaml
+        hasDocuments:
+          count: 1
+      - template: serviceaccount.yaml
+        hasDocuments:
+          count: 1
+      - template: clusterrole.yaml
+        hasDocuments:
+          count: 0
+      - template: clusterrolebinding.yaml
+        hasDocuments:
+          count: 0
+
   - it: should reference correct service account in ClusterRoleBinding with custom name
     template: clusterrolebinding.yaml
     set:

--- a/charts/extractedprism/tests/rbac_test.yaml
+++ b/charts/extractedprism/tests/rbac_test.yaml
@@ -82,3 +82,19 @@ tests:
       - equal:
           path: subjects[0].name
           value: RELEASE-NAME-extractedprism
+
+  - it: should not create ClusterRole when enableDiscovery is false
+    template: clusterrole.yaml
+    set:
+      enableDiscovery: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create ClusterRoleBinding when enableDiscovery is false
+    template: clusterrolebinding.yaml
+    set:
+      enableDiscovery: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Summary

- Make ClusterRole and ClusterRoleBinding conditional on `enableDiscovery` value
- When `enableDiscovery: false`, EndpointSlice RBAC resources are not created (unnecessary without Kubernetes discovery)
- ServiceAccount creation remains independently controlled via `serviceAccount.create`

## Test plan

- [x] 42 helm-unittest tests pass (3 new tests added)
- [x] `helm lint` passes
- [ ] CI lint-test passes