### PR TITLE
fix(renovate): skip private edc-connector image lookup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
+  "ignoreDeps": [
+    "ghcr.io/lexfrei/edc-connector"
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
# Pull Request

## Description

Skip Renovate dependency lookup for `ghcr.io/lexfrei/edc-connector` — it's a private registry image that causes package lookup failures during Renovate runs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

N/A — no chart changes, only Renovate configuration.

## Additional context

Verified locally with `renovate --platform=local --dry-run=full` — the lookup failure warning is gone after the fix.