### PR TITLE
feat(extractedprism): update to v0.3.0 with liveness detection and health bind address

### DIFF
--- a/charts/extractedprism/Chart.yaml
+++ b/charts/extractedprism/Chart.yaml
@@ -2,7 +2,13 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
     - kind: changed
-      description: Update dependency lexfrei/extractedprism to v0.2.1
+      description: Update appVersion to v0.3.0
+    - kind: added
+      description: Add healthBindAddress value for separate health server bind address
+    - kind: added
+      description: Add livenessInterval and livenessThreshold values for liveness detection tuning
+    - kind: changed
+      description: Extend logLevel to support dpanic, panic, and fatal levels
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -18,9 +24,9 @@ home: https://github.com/lexfrei/charts/
 name: extractedprism
 description: Per-node TCP load balancer for Kubernetes API server high availability
 type: application
-version: 0.1.6
+version: 0.2.0
 # renovate: datasource=github-releases depName=lexfrei/extractedprism
-appVersion: "v0.2.1"
+appVersion: "v0.3.0"
 keywords:
   - load-balancer
   - control-plane

--- a/charts/extractedprism/README.md
+++ b/charts/extractedprism/README.md
@@ -1,6 +1,6 @@
 # extractedprism
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.1](https://img.shields.io/badge/AppVersion-v0.2.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.3.0](https://img.shields.io/badge/AppVersion-v0.3.0-informational?style=flat-square)
 
 ## Status
 
@@ -25,7 +25,7 @@ extractedprism is a per-node TCP load balancer for Kubernetes API server high av
 
 ```bash
 helm install extractedprism oci://ghcr.io/lexfrei/charts/extractedprism \
-  --version 0.1.6 \
+  --version 0.2.0 \
   --set endpoints="10.0.0.1:6443,10.0.0.2:6443,10.0.0.3:6443"
 ```
 
@@ -53,7 +53,7 @@ helm uninstall extractedprism
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/extractedprism:0.1.6 \
+  ghcr.io/lexfrei/charts/extractedprism:0.2.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -69,6 +69,7 @@ cosign verify \
 | enableDiscovery | bool | `true` | Enable Kubernetes endpoint discovery (watches EndpointSlice API). When true, dynamically discovers API server endpoints in addition to static ones. |
 | endpoints | string | `""` | Comma-separated list of control plane endpoints (host:port). Required. These are the static bootstrap endpoints used before Kubernetes API discovery is available (e.g., before CNI starts). |
 | fullnameOverride | string | `""` | Override the full name of the chart |
+| healthBindAddress | string | `""` | Address to bind the health HTTP server (defaults to bindAddress if empty). Useful when the LB should stay on 127.0.0.1 but health probes need to be reachable from outside (e.g., "0.0.0.0"). |
 | healthInterval | string | `"20s"` | Interval between upstream health checks |
 | healthPort | int | `7446` | Port for the HTTP health check server |
 | healthTimeout | string | `"15s"` | Timeout for each upstream health check |
@@ -77,8 +78,10 @@ cosign verify \
 | image.repository | string | `"ghcr.io/lexfrei/extractedprism"` | Container image repository |
 | image.tag | string | `""` | Container image tag (defaults to chart appVersion if not set) |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
+| livenessInterval | string | `"5s"` | Heartbeat probe interval for liveness detection |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"host":"127.0.0.1","path":"/healthz","port":7446},"initialDelaySeconds":10,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
-| logLevel | string | `"info"` | Log level (debug, info, warn, error) |
+| livenessThreshold | string | `"15s"` | Maximum time since last heartbeat before liveness fails |
+| logLevel | string | `"info"` | Log level (debug, info, warn, error, dpanic, panic, fatal) |
 | nameOverride | string | `""` | Override the name of the chart |
 | nodeSelector | object | `{}` | Node selector for pod assignment |
 | podAnnotations | object | `{}` | Annotations for pods |

--- a/charts/extractedprism/templates/daemonset.yaml
+++ b/charts/extractedprism/templates/daemonset.yaml
@@ -66,10 +66,18 @@ spec:
             - {{ .Values.bindPort | quote }}
             - "--health-port"
             - {{ .Values.healthPort | quote }}
+            {{- if .Values.healthBindAddress }}
+            - "--health-bind-address"
+            - {{ .Values.healthBindAddress | quote }}
+            {{- end }}
             - "--health-interval"
             - {{ .Values.healthInterval | quote }}
             - "--health-timeout"
             - {{ .Values.healthTimeout | quote }}
+            - "--liveness-interval"
+            - {{ .Values.livenessInterval | quote }}
+            - "--liveness-threshold"
+            - {{ .Values.livenessThreshold | quote }}
             - "--enable-discovery={{ .Values.enableDiscovery }}"
             - "--log-level"
             - {{ .Values.logLevel | quote }}

--- a/charts/extractedprism/tests/daemonset_test.yaml
+++ b/charts/extractedprism/tests/daemonset_test.yaml
@@ -112,8 +112,11 @@ tests:
       bindAddress: "0.0.0.0"
       bindPort: 8445
       healthPort: 8446
+      healthBindAddress: "0.0.0.0"
       healthInterval: "30s"
       healthTimeout: "10s"
+      livenessInterval: "10s"
+      livenessThreshold: "30s"
       enableDiscovery: false
       logLevel: "debug"
     asserts:
@@ -137,6 +140,9 @@ tests:
           content: "8446"
       - contains:
           path: spec.template.spec.containers[0].args
+          content: "--health-bind-address"
+      - contains:
+          path: spec.template.spec.containers[0].args
           content: "--health-interval"
       - contains:
           path: spec.template.spec.containers[0].args
@@ -149,6 +155,12 @@ tests:
           content: "10s"
       - contains:
           path: spec.template.spec.containers[0].args
+          content: "--liveness-interval"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--liveness-threshold"
+      - contains:
+          path: spec.template.spec.containers[0].args
           content: "--enable-discovery=false"
       - contains:
           path: spec.template.spec.containers[0].args
@@ -156,6 +168,27 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "debug"
+
+  - it: should not include health-bind-address when empty
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--health-bind-address"
+
+  - it: should pass default liveness flags
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--liveness-interval"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "5s"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--liveness-threshold"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "15s"
 
   - it: should have readiness probe on /readyz with localhost host
     asserts:

--- a/charts/extractedprism/values.schema.json
+++ b/charts/extractedprism/values.schema.json
@@ -56,6 +56,10 @@
       "maximum": 65535,
       "description": "Port for the HTTP health check server"
     },
+    "healthBindAddress": {
+      "type": "string",
+      "description": "Address to bind the health HTTP server (defaults to bindAddress if empty)"
+    },
     "healthInterval": {
       "type": "string",
       "pattern": "^[0-9]+(s|m|h)$",
@@ -66,13 +70,23 @@
       "pattern": "^[0-9]+(s|m|h)$",
       "description": "Timeout for each upstream health check"
     },
+    "livenessInterval": {
+      "type": "string",
+      "pattern": "^[0-9]+(s|m|h)$",
+      "description": "Heartbeat probe interval for liveness detection"
+    },
+    "livenessThreshold": {
+      "type": "string",
+      "pattern": "^[0-9]+(s|m|h)$",
+      "description": "Maximum time since last heartbeat before liveness fails"
+    },
     "enableDiscovery": {
       "type": "boolean",
       "description": "Enable Kubernetes endpoint discovery"
     },
     "logLevel": {
       "type": "string",
-      "enum": ["debug", "info", "warn", "error"],
+      "enum": ["debug", "info", "warn", "error", "dpanic", "panic", "fatal"],
       "description": "Log level"
     },
     "updateStrategy": {

--- a/charts/extractedprism/values.yaml
+++ b/charts/extractedprism/values.yaml
@@ -33,17 +33,28 @@ bindPort: 7445
 # -- Port for the HTTP health check server
 healthPort: 7446
 
+# -- Address to bind the health HTTP server (defaults to bindAddress if empty).
+# Useful when the LB should stay on 127.0.0.1 but health probes need to be
+# reachable from outside (e.g., "0.0.0.0").
+healthBindAddress: ""
+
 # -- Interval between upstream health checks
 healthInterval: "20s"
 
 # -- Timeout for each upstream health check
 healthTimeout: "15s"
 
+# -- Heartbeat probe interval for liveness detection
+livenessInterval: "5s"
+
+# -- Maximum time since last heartbeat before liveness fails
+livenessThreshold: "15s"
+
 # -- Enable Kubernetes endpoint discovery (watches EndpointSlice API).
 # When true, dynamically discovers API server endpoints in addition to static ones.
 enableDiscovery: true
 
-# -- Log level (debug, info, warn, error)
+# -- Log level (debug, info, warn, error, dpanic, panic, fatal)
 logLevel: "info"
 
 updateStrategy:


### PR DESCRIPTION
# Pull Request

## Description

Update extractedprism chart to appVersion v0.3.0. This release adds liveness detection with heartbeat mechanism, a separate health server bind address, and extends supported log levels.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior

## Additional context

New values added:
- `healthBindAddress` — allows health server to listen on a different address than the LB (e.g., `0.0.0.0` for external probes)
- `livenessInterval` / `livenessThreshold` — tune heartbeat-based deadlock detection in `/healthz`
- `logLevel` enum extended with `dpanic`, `panic`, `fatal`