### PR TITLE
fix(vipalived): isolate static pod scheduling hints from DaemonSet values

### DIFF
--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -2,7 +2,9 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
     - kind: fixed
-      description: Use catch-all toleration to ensure scheduling on nodes with arbitrary taints
+      description: Static pod no longer inherits DaemonSet nodeSelector/affinity/tolerations; use new staticNodeSelector/staticAffinity/staticTolerations values for static-mode scheduling hints
+    - kind: added
+      description: New values staticNodeSelector, staticAffinity, staticTolerations for the static Pod manifest (defaults empty)
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +18,7 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.6.1
+version: 0.7.0
 # renovate: datasource=docker depName=alpine
 appVersion: "3.23"
 keywords:

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -1,6 +1,6 @@
 # vipalived
 
-![Version: 0.6.1](https://img.shields.io/badge/Version-0.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.23](https://img.shields.io/badge/AppVersion-3.23-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.23](https://img.shields.io/badge/AppVersion-3.23-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -16,16 +16,16 @@ Keepalived-based VIP management for Kubernetes control plane high availability
 
 ```bash
 # Day 2: Install with default VIP (172.16.101.101/32) on existing cluster
-helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.6.1
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.7.0
 
 # Day 2: Install with custom VIP address
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.6.1 \
+  --version 0.7.0 \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
 
 # Day 1: Generate static pod manifest for cluster bootstrap
 helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.6.1 \
+  --version 0.7.0 \
   --set static=true \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
 ```
@@ -75,7 +75,7 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 
    ```bash
    helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-     --version 0.6.1 \
+     --version 0.7.0 \
      --set static=true \
      --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR \
      --namespace kube-system > vipalived-static-pod.yaml
@@ -109,6 +109,20 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 - Each control plane node runs its own instance of the static pod
 - After cluster bootstrap, you can transition to the Helm-managed DaemonSet for easier management
 
+**Scheduling hints in static mode:**
+
+The DaemonSet-mode values (`nodeSelector`, `affinity`, `tolerations`) are **ignored** when `static: true`. Static pods are placed by kubelet directly — the manifest only runs on the node where it sits in `/etc/kubernetes/manifests/`. A non-matching `nodeSelector`/`nodeAffinity` on a static pod causes the API server to reject the mirror pod with `Predicate NodeAffinity failed`, and the pod never starts.
+
+If you still want defense-in-depth (so an accidentally-placed manifest fails loudly on the wrong node), use the dedicated keys:
+
+```yaml
+static: true
+staticNodeSelector:
+  node-role.kubernetes.io/control-plane: "true"
+staticAffinity: {}      # default empty
+staticTolerations: []   # default empty (kubelet doesn't enforce taint tolerance for static pods)
+```
+
 ## Installing the Chart
 
 To install the chart with the release name `my-vipalived`:
@@ -138,7 +152,7 @@ All charts published to GHCR are signed using cosign. To verify the chart signat
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/vipalived:0.6.1 \
+  ghcr.io/lexfrei/charts/vipalived:0.7.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -147,7 +161,7 @@ cosign verify \
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` | Affinity rules for pod assignment |
+| affinity | object | `{}` | Affinity rules for pod assignment (DaemonSet mode only). Ignored when `static: true` — static pods use `staticAffinity` instead. |
 | fullnameOverride | string | `""` | Override the full name of the chart |
 | hostNetwork | bool | `true` | Enable host network mode (required for VIP functionality) |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
@@ -181,7 +195,7 @@ cosign verify \
 | livenessProbe.timeoutSeconds | int | `5` | Timeout for liveness probe |
 | nameOverride | string | `""` | Override the name of the chart |
 | namespace | string | `"kube-system"` | Namespace to deploy vipalived into |
-| nodeSelector | object | `{"node-role.kubernetes.io/control-plane":"true"}` | Node selector for pod assignment |
+| nodeSelector | object | `{"node-role.kubernetes.io/control-plane":"true"}` | Node selector for pod assignment (DaemonSet mode only). Ignored when `static: true` — static pods use `staticNodeSelector` instead. |
 | podAnnotations | object | `{}` | Annotations for pods |
 | podLabels | object | `{}` | Additional labels for pods |
 | podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the pod |
@@ -204,7 +218,10 @@ cosign verify \
 | startupProbe.periodSeconds | int | `5` | Period between startup probe checks |
 | startupProbe.timeoutSeconds | int | `5` | Timeout for startup probe |
 | static | bool | `false` | Enable static pod mode for Day 1 cluster bootstrap. When true, renders a Pod manifest instead of DaemonSet with embedded configuration. Use this for pre-CNI VIP availability during initial cluster setup. For Day 2 operations (existing cluster), keep this false (default). |
-| tolerations | list | `[{"operator":"Exists"}]` | Tolerations for pod assignment. Uses catch-all toleration by default because vipalived is critical infrastructure that MUST run on every control-plane node regardless of any taints applied (e.g., workload-specific taints like minecraft=true:NoExecute). |
+| staticAffinity | object | `{}` | Affinity rules for the static Pod manifest (used only when `static: true`). Default is empty for the same reason as `staticNodeSelector`: nodeAffinity is enforced against the mirror pod and breaks placement if it doesn't match the node where the manifest sits. |
+| staticNodeSelector | object | `{}` | Node selector for the static Pod manifest (used only when `static: true`). Default is empty: kubelet places the static pod by virtue of the manifest living in `/etc/kubernetes/manifests/` on a given node, so a selector is normally redundant. Set explicitly only as defense-in-depth — a non-matching selector on a static pod causes the API server to reject the mirror pod with "Predicate NodeAffinity failed" and the pod never starts. |
+| staticTolerations | list | `[]` | Tolerations for the static Pod manifest (used only when `static: true`). Default is empty: kubelet does not enforce taint tolerance for static pods, so this is a no-op in practice. Provided for API parity with DaemonSet mode. |
+| tolerations | list | `[{"operator":"Exists"}]` | Tolerations for pod assignment (DaemonSet mode only). Ignored when `static: true` — static pods use `staticTolerations` instead. Uses catch-all toleration by default because vipalived is critical infrastructure that MUST run on every control-plane node regardless of any taints applied (e.g., workload-specific taints like minecraft=true:NoExecute). |
 | updateStrategy.maxUnavailable | int | `1` | Maximum number of unavailable pods during update |
 | updateStrategy.type | string | `"RollingUpdate"` | Update strategy type |
 

--- a/charts/vipalived/README.md.gotmpl
+++ b/charts/vipalived/README.md.gotmpl
@@ -109,6 +109,20 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 - Each control plane node runs its own instance of the static pod
 - After cluster bootstrap, you can transition to the Helm-managed DaemonSet for easier management
 
+**Scheduling hints in static mode:**
+
+The DaemonSet-mode values (`nodeSelector`, `affinity`, `tolerations`) are **ignored** when `static: true`. Static pods are placed by kubelet directly — the manifest only runs on the node where it sits in `/etc/kubernetes/manifests/`. A non-matching `nodeSelector`/`nodeAffinity` on a static pod causes the API server to reject the mirror pod with `Predicate NodeAffinity failed`, and the pod never starts.
+
+If you still want defense-in-depth (so an accidentally-placed manifest fails loudly on the wrong node), use the dedicated keys:
+
+```yaml
+static: true
+staticNodeSelector:
+  node-role.kubernetes.io/control-plane: "true"
+staticAffinity: {}      # default empty
+staticTolerations: []   # default empty (kubelet doesn't enforce taint tolerance for static pods)
+```
+
 ## Installing the Chart
 
 To install the chart with the release name `my-vipalived`:

--- a/charts/vipalived/templates/pod.yaml
+++ b/charts/vipalived/templates/pod.yaml
@@ -26,15 +26,24 @@ spec:
   securityContext:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.nodeSelector }}
+  {{- /*
+    Static pods consult dedicated scheduling values (staticNodeSelector /
+    staticAffinity / staticTolerations) so the DaemonSet defaults don't leak
+    into a static pod manifest. nodeSelector and nodeAffinity on a static pod
+    are evaluated by NodeRestriction admission against the mirror pod —
+    a non-matching selector causes "Predicate NodeAffinity failed" and the pod
+    never starts. Defaults are empty; operator sets them only as defense-in-depth
+    against placing the manifest on the wrong node.
+  */ -}}
+  {{- with .Values.staticNodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.affinity }}
+  {{- with .Values.staticAffinity }}
   affinity:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.tolerations }}
+  {{- with .Values.staticTolerations }}
   tolerations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/vipalived/tests/pod_test.yaml
+++ b/charts/vipalived/tests/pod_test.yaml
@@ -130,31 +130,27 @@ tests:
           path: spec.containers[0].resources.requests.memory
           value: "64Mi"
 
-  - it: should apply nodeSelector
+  - it: should not render scheduling hints by default in static mode
+    set:
+      static: true
+    asserts:
+      - isNull:
+          path: spec.nodeSelector
+      - isNull:
+          path: spec.affinity
+      - isNull:
+          path: spec.tolerations
+
+  - it: should not leak DaemonSet nodeSelector into static pod
     set:
       static: true
       nodeSelector:
         node-role.kubernetes.io/control-plane: "true"
     asserts:
-      - equal:
+      - isNull:
           path: spec.nodeSelector
-          value:
-            node-role.kubernetes.io/control-plane: "true"
 
-  - it: should apply tolerations
-    set:
-      static: true
-      tolerations:
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
-    asserts:
-      - contains:
-          path: spec.tolerations
-          content:
-            key: node-role.kubernetes.io/control-plane
-            effect: NoSchedule
-
-  - it: should apply affinity
+  - it: should not leak DaemonSet affinity into static pod
     set:
       static: true
       affinity:
@@ -165,8 +161,55 @@ tests:
                   - key: node-role.kubernetes.io/control-plane
                     operator: Exists
     asserts:
+      - isNull:
+          path: spec.affinity
+
+  - it: should not leak DaemonSet tolerations into static pod
+    set:
+      static: true
+      tolerations:
+        - operator: Exists
+    asserts:
+      - isNull:
+          path: spec.tolerations
+
+  - it: should apply staticNodeSelector when set
+    set:
+      static: true
+      staticNodeSelector:
+        node-role.kubernetes.io/control-plane: "true"
+    asserts:
+      - equal:
+          path: spec.nodeSelector
+          value:
+            node-role.kubernetes.io/control-plane: "true"
+
+  - it: should apply staticAffinity when set
+    set:
+      static: true
+      staticAffinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: Exists
+    asserts:
       - isNotNull:
           path: spec.affinity.nodeAffinity
+
+  - it: should apply staticTolerations when set
+    set:
+      static: true
+      staticTolerations:
+        - key: node-role.kubernetes.io/control-plane
+          effect: NoSchedule
+    asserts:
+      - contains:
+          path: spec.tolerations
+          content:
+            key: node-role.kubernetes.io/control-plane
+            effect: NoSchedule
 
   - it: should apply priorityClassName
     set:

--- a/charts/vipalived/values.schema.json
+++ b/charts/vipalived/values.schema.json
@@ -182,18 +182,36 @@
     },
     "nodeSelector": {
       "type": "object",
-      "description": "Node selector for pod assignment"
+      "description": "Node selector for pod assignment (DaemonSet mode only; ignored when static is true)"
     },
     "tolerations": {
       "type": "array",
       "items": {
         "type": "object"
       },
-      "description": "Tolerations for pod assignment"
+      "description": "Tolerations for pod assignment (DaemonSet mode only; ignored when static is true)"
     },
     "affinity": {
       "type": "object",
-      "description": "Affinity rules for pod assignment"
+      "description": "Affinity rules for pod assignment (DaemonSet mode only; ignored when static is true)"
+    },
+    "staticNodeSelector": {
+      "type": "object",
+      "description": "Node selector for the static Pod manifest (used only when static is true). Default empty; set as defense-in-depth.",
+      "default": {}
+    },
+    "staticAffinity": {
+      "type": "object",
+      "description": "Affinity rules for the static Pod manifest (used only when static is true). Default empty.",
+      "default": {}
+    },
+    "staticTolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Tolerations for the static Pod manifest (used only when static is true). Default empty; kubelet does not enforce taint tolerance on static pods.",
+      "default": []
     },
     "podSecurityContext": {
       "type": "object",

--- a/charts/vipalived/values.yaml
+++ b/charts/vipalived/values.yaml
@@ -87,19 +87,41 @@ hostNetwork: true
 # -- Priority class name for pod scheduling
 priorityClassName: system-node-critical
 
-# -- Node selector for pod assignment
+# -- Node selector for pod assignment (DaemonSet mode only).
+# Ignored when `static: true` — static pods use `staticNodeSelector` instead.
 nodeSelector:
   node-role.kubernetes.io/control-plane: "true"
 
-# -- Tolerations for pod assignment.
+# -- Tolerations for pod assignment (DaemonSet mode only).
+# Ignored when `static: true` — static pods use `staticTolerations` instead.
 # Uses catch-all toleration by default because vipalived is critical infrastructure
 # that MUST run on every control-plane node regardless of any taints applied
 # (e.g., workload-specific taints like minecraft=true:NoExecute).
 tolerations:
   - operator: Exists
 
-# -- Affinity rules for pod assignment
+# -- Affinity rules for pod assignment (DaemonSet mode only).
+# Ignored when `static: true` — static pods use `staticAffinity` instead.
 affinity: {}
+
+# -- Node selector for the static Pod manifest (used only when `static: true`).
+# Default is empty: kubelet places the static pod by virtue of the manifest
+# living in `/etc/kubernetes/manifests/` on a given node, so a selector is
+# normally redundant. Set explicitly only as defense-in-depth — a non-matching
+# selector on a static pod causes the API server to reject the mirror pod with
+# "Predicate NodeAffinity failed" and the pod never starts.
+staticNodeSelector: {}
+
+# -- Affinity rules for the static Pod manifest (used only when `static: true`).
+# Default is empty for the same reason as `staticNodeSelector`: nodeAffinity
+# is enforced against the mirror pod and breaks placement if it doesn't match
+# the node where the manifest sits.
+staticAffinity: {}
+
+# -- Tolerations for the static Pod manifest (used only when `static: true`).
+# Default is empty: kubelet does not enforce taint tolerance for static pods,
+# so this is a no-op in practice. Provided for API parity with DaemonSet mode.
+staticTolerations: []
 
 # -- Security context for the pod
 podSecurityContext:


### PR DESCRIPTION
## Summary

Static pods are placed by kubelet directly, but `nodeSelector`/`nodeAffinity` on a static pod are still evaluated by the NodeRestriction admission plugin against the mirror pod. The chart's default `nodeSelector={node-role.kubernetes.io/control-plane: "true"}` therefore caused `Predicate NodeAffinity failed` on any node that did not carry the label, even when the operator deliberately placed the static manifest there.

## Changes

- `templates/pod.yaml` reads dedicated values: `staticNodeSelector`, `staticAffinity`, `staticTolerations`. DaemonSet-mode `nodeSelector`/`affinity`/`tolerations` no longer leak into the static manifest.
- New values default to empty, so out-of-the-box static mode no longer breaks. Operators who want defense-in-depth (manifest accidentally placed on the wrong node fails loudly via mirror-pod admission) can opt in by setting the new keys explicitly.
- DaemonSet path (`templates/daemonset.yaml`) is unchanged.
- Tests, schema, README, and changelog annotation updated.
- Chart bumped to `0.7.0` (behavior change for users who relied on DaemonSet values applying to the static pod).

## Migration

If you were running with `static: true` and relied on `nodeSelector`/`affinity`/`tolerations` to be rendered into the static pod, set them under the new `static*` keys instead.