### PR TITLE
feat(obico): add Obico server chart

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
           - charts/eclipse-edc
           - charts/extractedprism
           - charts/me-site
+          - charts/obico
           - charts/system-upgrade-controller
           - charts/transmission
           - charts/vipalived
@@ -65,6 +66,7 @@ jobs:
           - charts/eclipse-edc
           - charts/extractedprism
           - charts/me-site
+          - charts/obico
           - charts/system-upgrade-controller
           - charts/transmission
           - charts/vipalived

--- a/charts/obico/.helmignore
+++ b/charts/obico/.helmignore
@@ -1,0 +1,39 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+
+# Development and testing
+tests/
+*.test.yaml
+*.md.gotmpl
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Artifact Hub metadata (published separately)
+artifacthub-repo.yml

--- a/charts/obico/Chart.yaml
+++ b/charts/obico/Chart.yaml
@@ -1,0 +1,47 @@
+annotations:
+  artifacthub.io/category: ai-machine-learning
+  # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
+  # See: https://artifacthub.io/docs/topics/annotations/helm/
+  artifacthub.io/changes: |-
+    - kind: added
+      description: Initial release of the obico-server chart
+  artifacthub.io/license: BSD-3-Clause
+  artifacthub.io/links: |
+    - name: Chart Repository
+      url: https://github.com/lexfrei/charts/
+    - name: Obico Server
+      url: https://github.com/TheSpaghettiDetective/obico-server/
+    - name: Container Images
+      url: https://github.com/lexfrei/images/
+  artifacthub.io/signKey: |
+    fingerprint: keyless
+    url: https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master
+apiVersion: v2
+name: obico
+description: Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper)
+type: application
+version: "0.1.0"
+# renovate: datasource=docker depName=ghcr.io/lexfrei/obico-web
+# CalVer derived from the obico-server release commit date (see lexfrei/images).
+appVersion: "2026.1.20"
+icon: https://www.obico.io/img/logo.svg
+home: https://github.com/lexfrei/charts/
+keywords:
+  - obico
+  - 3d-printing
+  - octoprint
+  - klipper
+  - monitoring
+  - ai
+  - spaghetti-detective
+  - helm-chart
+  - kubernetes
+maintainers:
+  - name: lexfrei
+    email: f@lex.la
+    url: https://github.com/lexfrei
+sources:
+  - https://github.com/lexfrei/charts/
+  - https://github.com/lexfrei/images/
+  - https://github.com/TheSpaghettiDetective/obico-server/
+kubeVersion: ">=1.21.0-0"

--- a/charts/obico/README.md
+++ b/charts/obico/README.md
@@ -1,0 +1,249 @@
+# obico
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.20](https://img.shields.io/badge/AppVersion-2026.1.20-informational?style=flat-square)
+
+## 📊 Status & Metrics
+
+[![Lint and Test](https://github.com/lexfrei/charts/actions/workflows/test.yaml/badge.svg)](https://github.com/lexfrei/charts/actions/workflows/test.yaml)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obico)](https://artifacthub.io/packages/helm/obico/obico)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
+[![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.21%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+
+Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper)
+
+**Homepage:** <https://github.com/lexfrei/charts/>
+
+## About
+
+[Obico](https://www.obico.io/) (formerly The Spaghetti Detective) is a self-hosted server that adds remote access, webcam streaming and AI-powered failure detection to OctoPrint and Klipper 3D printers.
+
+This chart deploys the full stack:
+
+- **web** — Django application served by Daphne (API, frontend, websockets)
+- **tasks** — Celery worker + beat scheduler (runs in the same pod as web)
+- **ml-api** — Flask/Gunicorn AI inference service for print-failure detection
+- **redis** — bundled Celery broker / Django Channels layer / cache
+
+The container images are built from obico-server source and published to GHCR ([lexfrei/images](https://github.com/lexfrei/images)); the chart tracks new builds automatically.
+
+The ML inference API is heavy (a CUDA-based image). Set `mlApi.enabled: false` to skip it — this disables AI print-failure detection (Obico's headline feature) but keeps remote access, webcam streaming and notifications working.
+
+## Images and auto-update
+
+Obico upstream does not publish ready-to-run images, so they are built from source in a separate repository. Both `obico-web` and `obico-ml-api` are built from one obico commit and share a single calendar-version tag (the chart `appVersion`). Renovate watches the image tag and bumps the chart automatically.
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| lexfrei | <f@lex.la> | <https://github.com/lexfrei> |
+
+## Source Code
+
+* <https://github.com/lexfrei/charts/>
+* <https://github.com/lexfrei/images/>
+* <https://github.com/TheSpaghettiDetective/obico-server/>
+
+## Requirements
+
+Kubernetes: `>=1.21.0-0`
+
+## Installing the Chart
+
+This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
+
+```bash
+# Install from GHCR
+helm install obico \
+  oci://ghcr.io/lexfrei/charts/obico \
+  --version 0.1.0
+
+# Install with custom values
+helm install obico \
+  oci://ghcr.io/lexfrei/charts/obico \
+  --version 0.1.0 \
+  --values values.yaml
+```
+
+### Chart Verification
+
+This chart is signed with [cosign](https://github.com/sigstore/cosign) using keyless signing:
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/obico:0.1.0 \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall obico
+```
+
+The data and media PVCs are annotated with `helm.sh/resource-policy: keep` and survive uninstall. Delete them manually if you no longer need the data.
+
+## Secret key (read before using GitOps)
+
+Obico needs a stable Django `SECRET_KEY`. Rotating it logs every user out and breaks signed tokens. Leaving `obico.secretKey` empty is only safe for a throwaway `helm install`: the empty-value fallback reuses the live Secret on upgrades, but **regenerates the key on every render-only path** — `helm template`, `--dry-run`, `helm diff` and ArgoCD (which renders with `helm template` and never reads the cluster). Under ArgoCD this rotates the key on every sync.
+
+For GitOps, do one of the following:
+
+```yaml
+# Set a stable key directly (e.g. openssl rand -base64 48)
+obico:
+  secretKey: "your-long-random-string"
+```
+
+```yaml
+# Or reference a Secret you manage (sealed-secrets, external-secrets, ...)
+# It must contain DJANGO_SECRET_KEY and any other sensitive env vars.
+obico:
+  existingSecret: obico-secrets
+```
+
+## Database
+
+The default configuration uses SQLite on the data volume so the chart installs with no external dependencies. **SQLite is for evaluation only:** the web server and the Celery worker are separate processes writing the same database file, so under real load they hit `database is locked` errors. Upstream Obico ships PostgreSQL only. For anything beyond a quick try-out, point `database.url` at an external PostgreSQL, or reference a Secret:
+
+```yaml
+# Plain connection string
+database:
+  url: "postgresql://obico:password@postgres:5432/obico"
+```
+
+```yaml
+# Connection string from an existing Secret
+database:
+  existingSecret: obico-db
+  existingSecretKey: DATABASE_URL
+```
+
+## Exposing the Web UI
+
+Either classic Ingress or Gateway API (HTTPRoute) can be used. Remember to set `obico.siteUsesHttps=true` when serving over HTTPS — Django 4 rejects HTTPS form posts (login, signup, admin) from untrusted origins. The chart derives `CSRF_TRUSTED_ORIGINS` automatically from the enabled ingress hosts / HTTPRoute hostnames using that scheme; override with `obico.csrfTrustedOrigins` if you front the app with a different hostname.
+
+```yaml
+# Ingress
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: obico.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: obico-tls
+      hosts:
+        - obico.example.com
+obico:
+  siteUsesHttps: true
+```
+
+```yaml
+# Gateway API
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+  hostnames:
+    - obico.example.com
+obico:
+  siteUsesHttps: true
+```
+
+## Scaling notes
+
+The web pod runs a single replica because the default SQLite database lives on a ReadWriteOnce volume. It uses the `Recreate` update strategy, so every upgrade or config change tears the pod down before starting the new one — expect a brief outage on each rollout. To run multiple replicas, use an external PostgreSQL and a ReadWriteMany media volume.
+
+## Bundled Redis
+
+The bundled Redis (`redis.enabled: true`) is a minimal, **unauthenticated** single instance intended for in-cluster use only. Do not expose it outside the cluster. For a hardened or shared Redis, set `redis.enabled: false` and point `redis.externalUrl` at your own instance.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| database | object | `{"existingSecret":"","existingSecretKey":"DATABASE_URL","url":"sqlite:////data/db.sqlite3"}` | Database configuration. Defaults to SQLite on the data volume. WARNING: SQLite is for evaluation only. The server and the Celery worker run as separate processes writing the same file, so under load they will hit "database is locked" errors. Upstream ships PostgreSQL only. For any real use set url to an external postgresql:// DSN, or reference a Secret via existingSecret/existingSecretKey. |
+| database.existingSecret | string | `""` | Use a key from an existing Secret for DATABASE_URL instead of url |
+| database.existingSecretKey | string | `"DATABASE_URL"` | Key inside existingSecret holding the DATABASE_URL value |
+| database.url | string | `"sqlite:////data/db.sqlite3"` | Database connection string (Django DATABASE_URL) |
+| fullnameOverride | string | `""` |  |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":["obico.example.com"],"parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | HTTPRoute configuration (Gateway API) |
+| httpRoute.hostnames | list | `["obico.example.com"]` | Hostnames for the route |
+| httpRoute.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Parent Gateway references |
+| httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules |
+| image | object | `{"mlApi":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-ml-api","tag":""},"web":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-web","tag":""}}` | Container images. Built from obico-server source and published to GHCR. Both images share the chart appVersion tag (one obico commit -> one tag). |
+| image.mlApi | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-ml-api","tag":""}` | ML inference API image (failure detection) |
+| image.mlApi.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| image.web | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-web","tag":""}` | Web application image (Django + Celery) |
+| image.web.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| imagePullSecrets | list | `[]` |  |
+| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"obico.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["obico.example.com"],"secretName":"obico-tls"}]}` | Ingress configuration |
+| mlApi | object | `{"command":["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"],"enabled":true,"replicaCount":1,"resources":{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{}}` | ML inference API (AI failure detection). Heavy image; can be disabled. |
+| mlApi.command | list | `["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"]` | Command for the gunicorn inference server |
+| mlApi.enabled | bool | `true` | Deploy the ML inference API |
+| mlApi.replicaCount | int | `1` | Number of ml-api replicas |
+| mlApi.resources | object | `{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resource requests/limits for the ml-api container |
+| mlApi.securityContext | object | `{}` | Security context for the ml-api container. Left empty (image default = root) because the upstream CUDA-based ml-api image is not validated to run unprivileged (model cache and runtime expect root). Harden here once confirmed it runs as non-root in your environment. |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| obico | object | `{"csrfTrustedOrigins":[],"debug":false,"existingSecret":"","extraEnv":{},"extraSecretEnv":{},"secretKey":"","siteUsesHttps":false}` | Obico application configuration (rendered into the env ConfigMap/Secret) |
+| obico.csrfTrustedOrigins | list | `[]` | CSRF trusted origins (Django 4+ rejects HTTPS POSTs from untrusted origins). Leave empty to auto-derive from the enabled ingress hosts / HTTPRoute hostnames using the scheme implied by siteUsesHttps. Set explicitly to override, e.g. ["https://obico.example.com"]. |
+| obico.debug | bool | `false` | Enable Django debug mode (never enable in production) |
+| obico.existingSecret | string | `""` | Reference a pre-created Secret for sensitive env (must contain DJANGO_SECRET_KEY and any other secret keys). When set, the chart does not create its own Secret and extraSecretEnv is ignored. Recommended for GitOps. |
+| obico.extraEnv | object | `{}` | Extra non-sensitive environment variables (key/value) for web and tasks. Chart-managed keys (DATABASE_URL, REDIS_URL, ...) are rejected here. Example: EMAIL_HOST: smtp.example.com |
+| obico.extraSecretEnv | object | `{}` | Extra sensitive environment variables (key/value) stored in the Secret. Example: EMAIL_HOST_PASSWORD: s3cr3t |
+| obico.secretKey | string | `""` | Django SECRET_KEY. IMPORTANT: leave empty only for a quick `helm install` test. The empty-value fallback reuses the live Secret on upgrades but REGENERATES the key on any render-only path (helm template, --dry-run, helm diff, ArgoCD) — rotating it logs every user out and rolls the pod on every sync. For GitOps set a stable value here (e.g. `openssl rand -base64 48`) or use existingSecret below. |
+| obico.siteUsesHttps | bool | `false` | Set to true when the site is served over HTTPS (behind a TLS ingress/gateway) |
+| persistence | object | `{"data":{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","retain":true,"size":"1Gi","storageClassName":""},"media":{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","retain":true,"size":"10Gi","storageClassName":""}}` | Persistence configuration |
+| persistence.data | object | `{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","retain":true,"size":"1Gi","storageClassName":""}` | Data volume (SQLite database and persistent data) |
+| persistence.data.accessMode | string | `"ReadWriteOnce"` | Access mode |
+| persistence.data.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.data.retain | bool | `true` | Keep the PVC when the release is uninstalled |
+| persistence.data.size | string | `"1Gi"` | Size of the volume |
+| persistence.data.storageClassName | string | `""` | Storage class name |
+| persistence.media | object | `{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","retain":true,"size":"10Gi","storageClassName":""}` | Media volume (user uploads, webcam frames, timelapses) |
+| persistence.media.accessMode | string | `"ReadWriteOnce"` | Access mode |
+| persistence.media.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.media.retain | bool | `true` | Keep the PVC when the release is uninstalled |
+| persistence.media.size | string | `"10Gi"` | Size of the volume |
+| persistence.media.storageClassName | string | `""` | Storage class name |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{"fsGroup":65534}` | Security context for the pod. fsGroup is load-bearing, not cosmetic: the server, tasks and migrate containers run as non-root (65534, see securityContext below), so the data and media volumes must be group-owned by that gid for them to write the SQLite DB and media files. It also lets the non-root server read the static assets generated by the root collectstatic init container. Keep them aligned. |
+| redis | object | `{"enabled":true,"externalUrl":"","image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.2-alpine"},"resources":{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":999}}` | Bundled Redis (Celery broker + Django Channels + cache) |
+| redis.enabled | bool | `true` | Deploy a minimal in-cluster Redis. Disable to use an external Redis. |
+| redis.externalUrl | string | `""` | External Redis URL, used when redis.enabled is false |
+| redis.image | object | `{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.2-alpine"}` | Redis image (pinned; not tied to the chart appVersion) |
+| redis.resources | object | `{"limits":{"cpu":"200m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"64Mi"}}` | Resource requests/limits for the redis container |
+| redis.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":999}` | Security context for the redis container |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsGroup":65534,"runAsNonRoot":true,"runAsUser":65534}` | Security context for the server, tasks and migrate containers |
+| service | object | `{"mlApi":{"annotations":{},"port":3333,"type":"ClusterIP"},"web":{"annotations":{},"port":3334,"type":"ClusterIP"}}` | Service configuration |
+| service.mlApi | object | `{"annotations":{},"port":3333,"type":"ClusterIP"}` | ML inference API service (internal) |
+| service.mlApi.annotations | object | `{}` | Annotations for the ml-api service |
+| service.mlApi.port | int | `3333` | HTTP port |
+| service.mlApi.type | string | `"ClusterIP"` | Service type for the ml-api |
+| service.web | object | `{"annotations":{},"port":3334,"type":"ClusterIP"}` | Web UI / API service (ClusterIP for Ingress/HTTPRoute) |
+| service.web.annotations | object | `{}` | Annotations for the web service |
+| service.web.port | int | `3334` | HTTP port |
+| service.web.type | string | `"ClusterIP"` | Service type for the web UI |
+| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Service account configuration |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use |
+| tasks | object | `{"command":["celery","-A","config","worker","--beat","-l","info","-c","2","-Q","realtime,celery"],"resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | Celery worker (runs in the same pod as the web server) |
+| tasks.command | list | `["celery","-A","config","worker","--beat","-l","info","-c","2","-Q","realtime,celery"]` | Command for the Celery worker with beat scheduler |
+| tasks.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the tasks container |
+| tolerations | list | `[]` |  |
+| web | object | `{"command":["daphne","-b","0.0.0.0","-p","3334","config.routing:application"],"resources":{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}}` | Web pod configuration (server + tasks containers, plus init containers) |
+| web.command | list | `["daphne","-b","0.0.0.0","-p","3334","config.routing:application"]` | Command for the Daphne ASGI server (serves API, frontend and websockets) |
+| web.resources | object | `{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}` | Resource requests/limits for the server container |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/obico/README.md
+++ b/charts/obico/README.md
@@ -20,10 +20,10 @@ Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper
 
 This chart deploys the full stack:
 
-- **web** — Django application served by Daphne (API, frontend, websockets)
-- **tasks** — Celery worker + beat scheduler (runs in the same pod as web)
-- **ml-api** — Flask/Gunicorn AI inference service for print-failure detection
-- **redis** — bundled Celery broker / Django Channels layer / cache
+* **web** — Django application served by Daphne (API, frontend, websockets)
+* **tasks** — Celery worker + beat scheduler (runs in the same pod as web)
+* **ml-api** — Flask/Gunicorn AI inference service for print-failure detection
+* **redis** — bundled Celery broker / Django Channels layer / cache
 
 The container images are built from obico-server source and published to GHCR ([lexfrei/images](https://github.com/lexfrei/images)); the chart tracks new builds automatically.
 

--- a/charts/obico/README.md.gotmpl
+++ b/charts/obico/README.md.gotmpl
@@ -1,0 +1,161 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+## 📊 Status & Metrics
+
+[![Lint and Test](https://github.com/lexfrei/charts/actions/workflows/test.yaml/badge.svg)](https://github.com/lexfrei/charts/actions/workflows/test.yaml)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/obico)](https://artifacthub.io/packages/helm/obico/obico)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
+[![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.21%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+## About
+
+[Obico](https://www.obico.io/) (formerly The Spaghetti Detective) is a self-hosted server that adds remote access, webcam streaming and AI-powered failure detection to OctoPrint and Klipper 3D printers.
+
+This chart deploys the full stack:
+
+- **web** — Django application served by Daphne (API, frontend, websockets)
+- **tasks** — Celery worker + beat scheduler (runs in the same pod as web)
+- **ml-api** — Flask/Gunicorn AI inference service for print-failure detection
+- **redis** — bundled Celery broker / Django Channels layer / cache
+
+The container images are built from obico-server source and published to GHCR ([lexfrei/images](https://github.com/lexfrei/images)); the chart tracks new builds automatically.
+
+The ML inference API is heavy (a CUDA-based image). Set `mlApi.enabled: false` to skip it — this disables AI print-failure detection (Obico's headline feature) but keeps remote access, webcam streaming and notifications working.
+
+## Images and auto-update
+
+Obico upstream does not publish ready-to-run images, so they are built from source in a separate repository. Both `obico-web` and `obico-ml-api` are built from one obico commit and share a single calendar-version tag (the chart `appVersion`). Renovate watches the image tag and bumps the chart automatically.
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installing the Chart
+
+This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
+
+```bash
+# Install from GHCR
+helm install obico \
+  oci://ghcr.io/lexfrei/charts/obico \
+  --version {{ template "chart.version" . }}
+
+# Install with custom values
+helm install obico \
+  oci://ghcr.io/lexfrei/charts/obico \
+  --version {{ template "chart.version" . }} \
+  --values values.yaml
+```
+
+### Chart Verification
+
+This chart is signed with [cosign](https://github.com/sigstore/cosign) using keyless signing:
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/obico:{{ template "chart.version" . }} \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+## Uninstalling the Chart
+
+```bash
+helm uninstall obico
+```
+
+The data and media PVCs are annotated with `helm.sh/resource-policy: keep` and survive uninstall. Delete them manually if you no longer need the data.
+
+## Secret key (read before using GitOps)
+
+Obico needs a stable Django `SECRET_KEY`. Rotating it logs every user out and breaks signed tokens. Leaving `obico.secretKey` empty is only safe for a throwaway `helm install`: the empty-value fallback reuses the live Secret on upgrades, but **regenerates the key on every render-only path** — `helm template`, `--dry-run`, `helm diff` and ArgoCD (which renders with `helm template` and never reads the cluster). Under ArgoCD this rotates the key on every sync.
+
+For GitOps, do one of the following:
+
+```yaml
+# Set a stable key directly (e.g. openssl rand -base64 48)
+obico:
+  secretKey: "your-long-random-string"
+```
+
+```yaml
+# Or reference a Secret you manage (sealed-secrets, external-secrets, ...)
+# It must contain DJANGO_SECRET_KEY and any other sensitive env vars.
+obico:
+  existingSecret: obico-secrets
+```
+
+## Database
+
+The default configuration uses SQLite on the data volume so the chart installs with no external dependencies. **SQLite is for evaluation only:** the web server and the Celery worker are separate processes writing the same database file, so under real load they hit `database is locked` errors. Upstream Obico ships PostgreSQL only. For anything beyond a quick try-out, point `database.url` at an external PostgreSQL, or reference a Secret:
+
+```yaml
+# Plain connection string
+database:
+  url: "postgresql://obico:password@postgres:5432/obico"
+```
+
+```yaml
+# Connection string from an existing Secret
+database:
+  existingSecret: obico-db
+  existingSecretKey: DATABASE_URL
+```
+
+## Exposing the Web UI
+
+Either classic Ingress or Gateway API (HTTPRoute) can be used. Remember to set `obico.siteUsesHttps=true` when serving over HTTPS — Django 4 rejects HTTPS form posts (login, signup, admin) from untrusted origins. The chart derives `CSRF_TRUSTED_ORIGINS` automatically from the enabled ingress hosts / HTTPRoute hostnames using that scheme; override with `obico.csrfTrustedOrigins` if you front the app with a different hostname.
+
+```yaml
+# Ingress
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: obico.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: obico-tls
+      hosts:
+        - obico.example.com
+obico:
+  siteUsesHttps: true
+```
+
+```yaml
+# Gateway API
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+  hostnames:
+    - obico.example.com
+obico:
+  siteUsesHttps: true
+```
+
+## Scaling notes
+
+The web pod runs a single replica because the default SQLite database lives on a ReadWriteOnce volume. It uses the `Recreate` update strategy, so every upgrade or config change tears the pod down before starting the new one — expect a brief outage on each rollout. To run multiple replicas, use an external PostgreSQL and a ReadWriteMany media volume.
+
+## Bundled Redis
+
+The bundled Redis (`redis.enabled: true`) is a minimal, **unauthenticated** single instance intended for in-cluster use only. Do not expose it outside the cluster. For a hardened or shared Redis, set `redis.enabled: false` and point `redis.externalUrl` at your own instance.
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/obico/README.md.gotmpl
+++ b/charts/obico/README.md.gotmpl
@@ -22,10 +22,10 @@
 
 This chart deploys the full stack:
 
-- **web** — Django application served by Daphne (API, frontend, websockets)
-- **tasks** — Celery worker + beat scheduler (runs in the same pod as web)
-- **ml-api** — Flask/Gunicorn AI inference service for print-failure detection
-- **redis** — bundled Celery broker / Django Channels layer / cache
+* **web** — Django application served by Daphne (API, frontend, websockets)
+* **tasks** — Celery worker + beat scheduler (runs in the same pod as web)
+* **ml-api** — Flask/Gunicorn AI inference service for print-failure detection
+* **redis** — bundled Celery broker / Django Channels layer / cache
 
 The container images are built from obico-server source and published to GHCR ([lexfrei/images](https://github.com/lexfrei/images)); the chart tracks new builds automatically.
 

--- a/charts/obico/templates/NOTES.txt
+++ b/charts/obico/templates/NOTES.txt
@@ -1,0 +1,59 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Obico server has been deployed.
+
+Release Name: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+Components:
+  - web (Django + Daphne) and tasks (Celery) in one pod
+  {{- if .Values.mlApi.enabled }}
+  - ml-api (AI failure detection)
+  {{- end }}
+  {{- if .Values.redis.enabled }}
+  - redis (bundled)
+  {{- end }}
+
+Database: {{ if .Values.database.existingSecret }}external (from secret {{ .Values.database.existingSecret }}){{ else }}{{ .Values.database.url }}{{ end }}
+
+To check the status of your deployment:
+
+  kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ include "obico.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+{{- if .Values.ingress.enabled }}
+
+Web UI is accessible at:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if .Values.httpRoute.enabled }}
+
+Web UI is accessible at:
+{{- range .Values.httpRoute.hostnames }}
+  - https://{{ . }}
+{{- end }}
+{{- else }}
+
+To access the Web UI, forward the port:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "obico.fullname" . }}-web {{ .Values.service.web.port }}:{{ .Values.service.web.port }}
+
+Then open: http://localhost:{{ .Values.service.web.port }}
+{{- end }}
+
+First-run setup:
+  1. Create an admin account by signing up in the web UI (first user is staff).
+  2. Configure the public URL under Settings if serving behind a proxy.
+{{- if not .Values.obico.siteUsesHttps }}
+  3. When serving over HTTPS, set obico.siteUsesHttps=true and upgrade.
+{{- end }}
+
+To view logs:
+
+  kubectl --namespace {{ .Release.Namespace }} logs -l "app.kubernetes.io/name={{ include "obico.name" . }},app.kubernetes.io/component=web" --tail=100 -f
+
+For more information:
+  - Chart: https://github.com/lexfrei/charts/tree/master/charts/obico
+  - Obico: https://www.obico.io/

--- a/charts/obico/templates/_helpers.tpl
+++ b/charts/obico/templates/_helpers.tpl
@@ -1,0 +1,179 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "obico.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "obico.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "obico.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "obico.labels" -}}
+helm.sh/chart: {{ include "obico.chart" . }}
+{{ include "obico.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels (shared across all components).
+Per-component templates add app.kubernetes.io/component to disambiguate pods.
+*/}}
+{{- define "obico.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "obico.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "obico.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "obico.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the Redis URL: bundled service when redis.enabled, otherwise external.
+*/}}
+{{- define "obico.redisUrl" -}}
+{{- if .Values.redis.enabled -}}
+redis://{{ include "obico.fullname" . }}-redis:6379/0
+{{- else if .Values.redis.externalUrl -}}
+{{- .Values.redis.externalUrl -}}
+{{- else -}}
+{{- fail "redis.enabled is false: set redis.externalUrl to an external Redis connection string" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Name of the Secret holding sensitive env (DJANGO_SECRET_KEY, ...).
+Use a pre-created Secret when obico.existingSecret is set, otherwise the
+chart-managed Secret named after the release.
+*/}}
+{{- define "obico.secretName" -}}
+{{- if .Values.obico.existingSecret -}}
+{{- .Values.obico.existingSecret -}}
+{{- else -}}
+{{- include "obico.fullname" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolve the Django SECRET_KEY for the chart-managed Secret.
+Prefer an explicit value; otherwise reuse the key from an existing Secret so it
+stays stable across live upgrades; otherwise generate a new random key.
+NOTE: the lookup-based reuse only works during a live `helm install/upgrade`.
+Render-only paths (helm template, --dry-run, helm diff, ArgoCD) cannot read the
+cluster, so they regenerate the key on every render. For GitOps set
+obico.secretKey explicitly or use obico.existingSecret.
+*/}}
+{{- define "obico.secretKey" -}}
+{{- if .Values.obico.secretKey -}}
+{{- .Values.obico.secretKey -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "obico.fullname" .) -}}
+{{- if and $existing $existing.data (index $existing.data "DJANGO_SECRET_KEY") -}}
+{{- index $existing.data "DJANGO_SECRET_KEY" | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 50 -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+JSON-encoded CSRF_TRUSTED_ORIGINS for Django. Django 4+ rejects HTTPS POSTs
+(login, signup, admin) whose origin is not listed here. Use an explicit
+obico.csrfTrustedOrigins list when set; otherwise derive origins from the
+ingress hosts and HTTPRoute hostnames, using the scheme implied by
+obico.siteUsesHttps.
+*/}}
+{{- define "obico.csrfTrustedOrigins" -}}
+{{- $scheme := ternary "https" "http" .Values.obico.siteUsesHttps -}}
+{{- $origins := list -}}
+{{- if .Values.obico.csrfTrustedOrigins -}}
+{{- $origins = .Values.obico.csrfTrustedOrigins -}}
+{{- else -}}
+{{- if .Values.ingress.enabled -}}
+{{- range .Values.ingress.hosts -}}
+{{- $origins = append $origins (printf "%s://%s" $scheme .host) -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.httpRoute.enabled -}}
+{{- range .Values.httpRoute.hostnames -}}
+{{- $origins = append $origins (printf "%s://%s" $scheme .) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $origins | toJson -}}
+{{- end }}
+
+{{/*
+Shared environment wiring for every web-image container (collectstatic, migrate,
+server, tasks). Keeping it in one place guarantees the containers stay identical
+by construction — e.g. the DATABASE_URL override is never accidentally dropped
+from one of them.
+*/}}
+{{- define "obico.podEnv" -}}
+envFrom:
+  - configMapRef:
+      name: {{ include "obico.fullname" . }}
+  - secretRef:
+      name: {{ include "obico.secretName" . }}
+{{- if .Values.database.existingSecret }}
+env:
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.database.existingSecret }}
+        key: {{ .Values.database.existingSecretKey }}
+{{- end }}
+{{- end }}
+
+{{/*
+Guard against overriding chart-managed environment variables through the
+free-form extraEnv / extraSecretEnv maps, which would silently win via
+later-key YAML semantics in the ConfigMap / Secret.
+*/}}
+{{- define "obico.checkReservedEnv" -}}
+{{- $reserved := list "DEBUG" "WEBPACK_LOADER_ENABLED" "SITE_USES_HTTPS" "REDIS_URL" "ML_API_HOST" "INTERNAL_MEDIA_HOST" "DATABASE_URL" "DJANGO_SECRET_KEY" "CSRF_TRUSTED_ORIGINS" -}}
+{{- range $key, $_ := .Values.obico.extraEnv -}}
+{{- if has $key $reserved -}}
+{{- fail (printf "obico.extraEnv must not set the chart-managed key %q; configure it via its dedicated value instead" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- range $key, $_ := .Values.obico.extraSecretEnv -}}
+{{- if has $key $reserved -}}
+{{- fail (printf "obico.extraSecretEnv must not set the chart-managed key %q; configure it via its dedicated value instead" $key) -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/obico/templates/configmap.yaml
+++ b/charts/obico/templates/configmap.yaml
@@ -1,0 +1,23 @@
+{{- include "obico.checkReservedEnv" . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "obico.fullname" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+data:
+  DEBUG: {{ ternary "True" "False" .Values.obico.debug | quote }}
+  WEBPACK_LOADER_ENABLED: "False"
+  SITE_USES_HTTPS: {{ ternary "True" "False" .Values.obico.siteUsesHttps | quote }}
+  CSRF_TRUSTED_ORIGINS: {{ include "obico.csrfTrustedOrigins" . | quote }}
+  REDIS_URL: {{ include "obico.redisUrl" . | quote }}
+  {{- if .Values.mlApi.enabled }}
+  ML_API_HOST: {{ printf "http://%s-ml-api:%v" (include "obico.fullname" .) .Values.service.mlApi.port | quote }}
+  {{- end }}
+  INTERNAL_MEDIA_HOST: {{ printf "http://%s-web:%v" (include "obico.fullname" .) .Values.service.web.port | quote }}
+  {{- if not .Values.database.existingSecret }}
+  DATABASE_URL: {{ .Values.database.url | quote }}
+  {{- end }}
+  {{- range $key, $value := .Values.obico.extraEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/obico/templates/deployment-ml-api.yaml
+++ b/charts/obico/templates/deployment-ml-api.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.mlApi.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "obico.fullname" . }}-ml-api
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ml-api
+spec:
+  replicas: {{ .Values.mlApi.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "obico.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ml-api
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "obico.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ml-api
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "obico.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      containers:
+        - name: ml-api
+          image: "{{ .Values.image.mlApi.repository }}:{{ .Values.image.mlApi.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.mlApi.pullPolicy }}
+          {{- with .Values.mlApi.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.mlApi.command | nindent 12 }}
+          env:
+            - name: FLASK_APP
+              value: server.py
+          ports:
+            - name: http
+              containerPort: 3333
+              protocol: TCP
+          # Cheap socket check for liveness; readiness uses /hc/.
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /hc/
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.mlApi.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/obico/templates/deployment-web.yaml
+++ b/charts/obico/templates/deployment-web.yaml
@@ -1,0 +1,180 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "obico.fullname" . }}-web
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  # SQLite on a ReadWriteOnce volume allows only a single writer. Scaling the
+  # web pod requires an external PostgreSQL and a ReadWriteMany media volume.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "obico.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "obico.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "obico.serviceAccountName" . }}
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: collectstatic
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          # Generates static assets into the shared static volume. Runs as root
+          # because the image's /app tree is owned by root.
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 0
+          command:
+            - python
+            - manage.py
+            - collectstatic
+            - -v
+            - "2"
+            - --noinput
+          {{- include "obico.podEnv" . | nindent 10 }}
+          volumeMounts:
+            - name: static
+              mountPath: /app/static_build
+        - name: migrate
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - python
+            - manage.py
+            - migrate
+            - --noinput
+          {{- include "obico.podEnv" . | nindent 10 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      containers:
+        - name: server
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.web.command | nindent 12 }}
+          {{- include "obico.podEnv" . | nindent 10 }}
+          ports:
+            - name: http
+              containerPort: 3334
+              protocol: TCP
+          # Liveness is a cheap socket check: the /hc/ endpoint queries the DB
+          # and Redis, so using it for liveness would restart the pod on any
+          # transient dependency blip. Readiness uses /hc/ to pull the pod out
+          # of the Service until its dependencies are back.
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /hc/
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          # static (emptyDir) holds collectstatic output; media (PVC) is mounted
+          # nested at static_build/media so user uploads land on the PVC while
+          # static assets stay in the emptyDir. collectstatic writes only static,
+          # so nothing it produces is shadowed by the media PVC. The tasks
+          # container does not serve static and so does not mount it.
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: media
+              mountPath: /app/static_build/media
+            - name: static
+              mountPath: /app/static_build
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+        # Celery worker. Intentionally has no liveness probe: it shares this pod
+        # with the server container, so a flaky `celery inspect ping` would
+        # restart the whole pod (including a healthy server). Worker health is
+        # observed via logs/metrics instead.
+        - name: tasks
+          image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.web.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            {{- toYaml .Values.tasks.command | nindent 12 }}
+          {{- include "obico.podEnv" . | nindent 10 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: media
+              mountPath: /app/static_build/media
+          resources:
+            {{- toYaml .Values.tasks.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.data.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.data.existingClaim }}
+          {{- else if .Values.persistence.data.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "obico.fullname" . }}-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: media
+          {{- if .Values.persistence.media.existingClaim }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.media.existingClaim }}
+          {{- else if .Values.persistence.media.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "obico.fullname" . }}-media
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: static
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/obico/templates/httproute.yaml
+++ b/charts/obico/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "obico.fullname" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "obico.fullname" $ }}-web
+          port: {{ $.Values.service.web.port }}
+          {{- with .weight }}
+          weight: {{ . }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/obico/templates/ingress.yaml
+++ b/charts/obico/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "obico.fullname" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "obico.fullname" $ }}-web
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/obico/templates/pvc-data.yaml
+++ b/charts/obico/templates/pvc-data.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "obico.fullname" . }}-data
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- if .Values.persistence.data.retain }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size }}
+  {{- if .Values.persistence.data.storageClassName }}
+  storageClassName: {{ .Values.persistence.data.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/obico/templates/pvc-media.yaml
+++ b/charts/obico/templates/pvc-media.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.persistence.media.enabled (not .Values.persistence.media.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "obico.fullname" . }}-media
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- if .Values.persistence.media.retain }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.media.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.media.size }}
+  {{- if .Values.persistence.media.storageClassName }}
+  storageClassName: {{ .Values.persistence.media.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/obico/templates/redis.yaml
+++ b/charts/obico/templates/redis.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "obico.fullname" . }}-redis
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "obico.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "obico.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          {{- with .Values.redis.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "obico.fullname" . }}-redis
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "obico.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/charts/obico/templates/secret.yaml
+++ b/charts/obico/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if not .Values.obico.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "obico.fullname" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  DJANGO_SECRET_KEY: {{ include "obico.secretKey" . | quote }}
+  {{- range $key, $value := .Values.obico.extraSecretEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/obico/templates/service.yaml
+++ b/charts/obico/templates/service.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "obico.fullname" . }}-web
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  {{- with .Values.service.web.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.web.type }}
+  ports:
+    - port: {{ .Values.service.web.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "obico.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+{{- if .Values.mlApi.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "obico.fullname" . }}-ml-api
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ml-api
+  {{- with .Values.service.mlApi.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.mlApi.type }}
+  ports:
+    - port: {{ .Values.service.mlApi.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "obico.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ml-api
+{{- end }}

--- a/charts/obico/templates/serviceaccount.yaml
+++ b/charts/obico/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "obico.serviceAccountName" . }}
+  labels:
+    {{- include "obico.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/obico/tests/chart_test.yaml
+++ b/charts/obico/tests/chart_test.yaml
@@ -1,0 +1,51 @@
+suite: test obico chart
+templates:
+  - deployment-web.yaml
+  - deployment-ml-api.yaml
+  - service.yaml
+  - serviceaccount.yaml
+  - configmap.yaml
+  - secret.yaml
+  - pvc-data.yaml
+  - pvc-media.yaml
+tests:
+  - it: should render all default resources
+    asserts:
+      - isKind:
+          of: Deployment
+        template: deployment-web.yaml
+      - isKind:
+          of: Deployment
+        template: deployment-ml-api.yaml
+      - isKind:
+          of: ServiceAccount
+        template: serviceaccount.yaml
+      - isKind:
+          of: ConfigMap
+        template: configmap.yaml
+      - isKind:
+          of: Secret
+        template: secret.yaml
+      - isKind:
+          of: PersistentVolumeClaim
+        template: pvc-data.yaml
+      - isKind:
+          of: PersistentVolumeClaim
+        template: pvc-media.yaml
+
+  - it: should set a web image tag matching the appVersion CalVer
+    template: deployment-web.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/lexfrei/obico-web:[0-9]{4}\.[0-9]+\.[0-9]+$'
+
+  - it: should include standard labels on the web deployment
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: obico
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: Helm

--- a/charts/obico/tests/configmap_test.yaml
+++ b/charts/obico/tests/configmap_test.yaml
@@ -1,0 +1,157 @@
+suite: test env configmap
+templates:
+  - configmap.yaml
+tests:
+  - it: should create a ConfigMap
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico
+
+  - it: should default DATABASE_URL to SQLite
+    asserts:
+      - equal:
+          path: data.DATABASE_URL
+          value: "sqlite:////data/db.sqlite3"
+
+  - it: should point REDIS_URL at the bundled redis
+    asserts:
+      - equal:
+          path: data.REDIS_URL
+          value: "redis://RELEASE-NAME-obico-redis:6379/0"
+
+  - it: should point ML_API_HOST at the ml-api service
+    asserts:
+      - equal:
+          path: data.ML_API_HOST
+          value: "http://RELEASE-NAME-obico-ml-api:3333"
+
+  - it: should set INTERNAL_MEDIA_HOST at the web service
+    asserts:
+      - equal:
+          path: data.INTERNAL_MEDIA_HOST
+          value: "http://RELEASE-NAME-obico-web:3334"
+
+  - it: should disable debug and webpack loader by default
+    asserts:
+      - equal:
+          path: data.DEBUG
+          value: "False"
+      - equal:
+          path: data.WEBPACK_LOADER_ENABLED
+          value: "False"
+
+  - it: should set SITE_USES_HTTPS to False by default
+    asserts:
+      - equal:
+          path: data.SITE_USES_HTTPS
+          value: "False"
+
+  - it: should reflect siteUsesHttps when enabled
+    set:
+      obico.siteUsesHttps: true
+    asserts:
+      - equal:
+          path: data.SITE_USES_HTTPS
+          value: "True"
+
+  - it: should allow overriding DATABASE_URL
+    set:
+      database.url: "postgresql://u:p@db:5432/obico"
+    asserts:
+      - equal:
+          path: data.DATABASE_URL
+          value: "postgresql://u:p@db:5432/obico"
+
+  - it: should use the external redis url when redis disabled
+    set:
+      redis.enabled: false
+      redis.externalUrl: "redis://my-redis:6379/1"
+    asserts:
+      - equal:
+          path: data.REDIS_URL
+          value: "redis://my-redis:6379/1"
+
+  - it: should merge extra env
+    set:
+      obico.extraEnv:
+        EMAIL_HOST: smtp.example.com
+    asserts:
+      - equal:
+          path: data.EMAIL_HOST
+          value: "smtp.example.com"
+
+  - it: should not set DATABASE_URL in the ConfigMap when using existingSecret
+    set:
+      database.existingSecret: my-db-secret
+    asserts:
+      - notExists:
+          path: data.DATABASE_URL
+
+  - it: should default CSRF_TRUSTED_ORIGINS to an empty list
+    asserts:
+      - equal:
+          path: data.CSRF_TRUSTED_ORIGINS
+          value: "[]"
+
+  - it: should derive CSRF_TRUSTED_ORIGINS from the ingress host over https
+    set:
+      ingress.enabled: true
+      obico.siteUsesHttps: true
+    asserts:
+      - equal:
+          path: data.CSRF_TRUSTED_ORIGINS
+          value: '["https://obico.example.com"]'
+
+  - it: should derive CSRF_TRUSTED_ORIGINS from the httpRoute hostname
+    set:
+      httpRoute.enabled: true
+      obico.siteUsesHttps: true
+    asserts:
+      - equal:
+          path: data.CSRF_TRUSTED_ORIGINS
+          value: '["https://obico.example.com"]'
+
+  - it: should use explicit csrfTrustedOrigins when set
+    set:
+      obico.csrfTrustedOrigins:
+        - https://custom.example.com
+    asserts:
+      - equal:
+          path: data.CSRF_TRUSTED_ORIGINS
+          value: '["https://custom.example.com"]'
+
+  - it: should omit ML_API_HOST when ml-api is disabled
+    set:
+      mlApi.enabled: false
+    asserts:
+      - notExists:
+          path: data.ML_API_HOST
+
+  - it: should reject CSRF_TRUSTED_ORIGINS in extraEnv
+    set:
+      obico.extraEnv:
+        CSRF_TRUSTED_ORIGINS: "[]"
+    asserts:
+      - failedTemplate:
+          errorMessage: 'obico.extraEnv must not set the chart-managed key "CSRF_TRUSTED_ORIGINS"; configure it via its dedicated value instead'
+
+  - it: should reject a chart-managed key in extraEnv
+    set:
+      obico.extraEnv:
+        REDIS_URL: redis://evil:6379
+    asserts:
+      - failedTemplate:
+          errorMessage: 'obico.extraEnv must not set the chart-managed key "REDIS_URL"; configure it via its dedicated value instead'
+
+  - it: should reject a chart-managed key in extraSecretEnv
+    set:
+      obico.extraSecretEnv:
+        DJANGO_SECRET_KEY: hunter2
+    asserts:
+      - failedTemplate:
+          errorMessage: 'obico.extraSecretEnv must not set the chart-managed key "DJANGO_SECRET_KEY"; configure it via its dedicated value instead'

--- a/charts/obico/tests/deployment_ml_api_test.yaml
+++ b/charts/obico/tests/deployment_ml_api_test.yaml
@@ -1,0 +1,74 @@
+suite: test ml-api deployment
+templates:
+  - deployment-ml-api.yaml
+tests:
+  - it: should create an ml-api Deployment by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-ml-api
+
+  - it: should not create ml-api when disabled
+    set:
+      mlApi.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use the ml-api image
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/lexfrei/obico-ml-api:'
+
+  - it: should expose port 3333
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 3333
+            protocol: TCP
+
+  - it: should run gunicorn
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: gunicorn
+
+  - it: should set the ml-api component label
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: ml-api
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: ml-api
+
+  - it: should honor replicaCount
+    set:
+      mlApi.replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should use a cheap socket liveness probe and an http readiness probe
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /hc/
+
+  - it: should not automount the service account token
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false

--- a/charts/obico/tests/deployment_web_test.yaml
+++ b/charts/obico/tests/deployment_web_test.yaml
@@ -1,0 +1,239 @@
+suite: test web deployment
+templates:
+  - deployment-web.yaml
+  - configmap.yaml
+  - secret.yaml
+tests:
+  - it: should create a single web Deployment
+    template: deployment-web.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-web
+
+  - it: should run a single replica
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+
+  - it: should set the web component label on selector and pod
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: web
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: web
+
+  - it: should run collectstatic and migrate init containers
+    template: deployment-web.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: collectstatic
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: migrate
+
+  - it: should run collectstatic as root
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+
+  - it: should have server and tasks containers
+    template: deployment-web.yaml
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: server
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: tasks
+
+  - it: should use the web image for both containers
+    template: deployment-web.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/lexfrei/obico-web:'
+      - matchRegex:
+          path: spec.template.spec.containers[1].image
+          pattern: '^ghcr\.io/lexfrei/obico-web:'
+
+  - it: should expose the http port on the server container
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: http
+            containerPort: 3334
+            protocol: TCP
+
+  - it: should run daphne as the server command
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: daphne
+
+  - it: should run celery as the tasks command
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].command
+          content: celery
+
+  - it: should load env from the ConfigMap and Secret
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: RELEASE-NAME-obico
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: RELEASE-NAME-obico
+
+  - it: should mount data, media and static volumes on the server
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /data
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: media
+            mountPath: /app/static_build/media
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: static
+            mountPath: /app/static_build
+
+  - it: should set the service account
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: RELEASE-NAME-obico
+
+  - it: should use a cheap socket liveness probe and an http readiness probe
+    template: deployment-web.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /hc/
+
+  - it: should not give the tasks container a liveness probe
+    template: deployment-web.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[1].livenessProbe
+
+  - it: should not automount the service account token
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should align fsGroup with the non-root containers and root collectstatic
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 65534
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.runAsUser
+          value: 0
+
+  - it: should inject DATABASE_URL from a Secret when using existingSecret
+    template: deployment-web.yaml
+    set:
+      database.existingSecret: my-db-secret
+      database.existingSecretKey: DATABASE_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: DATABASE_URL
+
+  - it: should inject DATABASE_URL into collectstatic, migrate and tasks under existingSecret
+    template: deployment-web.yaml
+    set:
+      database.existingSecret: my-db-secret
+      database.existingSecretKey: DATABASE_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: DATABASE_URL
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: DATABASE_URL
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: DATABASE_URL
+
+  - it: should reference the existing secret in envFrom when obico.existingSecret is set
+    template: deployment-web.yaml
+    set:
+      obico.existingSecret: obico-secrets
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: obico-secrets
+      - contains:
+          path: spec.template.spec.containers[1].envFrom
+          content:
+            secretRef:
+              name: obico-secrets

--- a/charts/obico/tests/httproute_test.yaml
+++ b/charts/obico/tests/httproute_test.yaml
@@ -1,0 +1,173 @@
+suite: test httproute
+templates:
+  - httproute.yaml
+tests:
+  - it: should not create HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create HTTPRoute when enabled
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: apiVersion
+          value: gateway.networking.k8s.io/v1
+
+  - it: should have correct metadata
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico
+      - isNotEmpty:
+          path: metadata.labels
+
+  - it: should set parentRefs correctly
+    set:
+      httpRoute.enabled: true
+      httpRoute.parentRefs:
+        - name: my-gateway
+          namespace: custom-namespace
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: my-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: custom-namespace
+
+  - it: should set hostnames correctly
+    set:
+      httpRoute.enabled: true
+      httpRoute.hostnames:
+        - obico.example.com
+        - obico.alt.com
+    asserts:
+      - contains:
+          path: spec.hostnames
+          content: obico.example.com
+      - contains:
+          path: spec.hostnames
+          content: obico.alt.com
+
+  - it: should point the backendRef at the web service
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-obico-web
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 3334
+
+  - it: should use a custom service port
+    set:
+      httpRoute.enabled: true
+      service.web.port: 8080
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8080
+
+  - it: should set path match correctly
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+
+  - it: should support custom annotations
+    set:
+      httpRoute.enabled: true
+      httpRoute.annotations:
+        custom.annotation/key: "value"
+    asserts:
+      - equal:
+          path: metadata.annotations["custom.annotation/key"]
+          value: "value"
+
+  - it: should support filters
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          filters:
+            - type: RequestHeaderModifier
+              requestHeaderModifier:
+                add:
+                  - name: X-Custom-Header
+                    value: custom-value
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+
+  - it: should support weight in backendRef
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          weight: 100
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 100
+
+  - it: should support multiple rules
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /api
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /web
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 2
+
+  - it: should support sectionName in parentRefs
+    set:
+      httpRoute.enabled: true
+      httpRoute.parentRefs:
+        - name: cilium-gateway-internal
+          namespace: kube-system
+          sectionName: https-obico
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https-obico
+
+  - it: should not have filters when not specified
+    set:
+      httpRoute.enabled: true
+    asserts:
+      - isNull:
+          path: spec.rules[0].filters

--- a/charts/obico/tests/ingress_test.yaml
+++ b/charts/obico/tests/ingress_test.yaml
@@ -1,0 +1,66 @@
+suite: test ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: should not create Ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create Ingress when enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+
+  - it: should point the backend at the web service
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-obico-web
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: http
+
+  - it: should configure default TLS
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: obico-tls
+
+  - it: should set the ingress class name
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should have no annotations by default
+    set:
+      ingress.enabled: true
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should apply custom annotations when specified
+    set:
+      ingress.enabled: true
+      ingress.annotations:
+        nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+        cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+          value: "100m"
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: "letsencrypt-prod"

--- a/charts/obico/tests/pvc_test.yaml
+++ b/charts/obico/tests/pvc_test.yaml
@@ -1,0 +1,75 @@
+suite: test persistence
+templates:
+  - pvc-data.yaml
+  - pvc-media.yaml
+tests:
+  - it: should create the data PVC by default
+    template: pvc-data.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-data
+      - equal:
+          path: spec.accessModes[0]
+          value: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 1Gi
+
+  - it: should create the media PVC by default
+    template: pvc-media.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-media
+      - equal:
+          path: spec.resources.requests.storage
+          value: 10Gi
+
+  - it: should not create the data PVC when disabled
+    template: pvc-data.yaml
+    set:
+      persistence.data.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create the data PVC when using an existing claim
+    template: pvc-data.yaml
+    set:
+      persistence.data.existingClaim: my-claim
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should add a keep resource-policy annotation when retain is true
+    template: pvc-data.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: should not add the keep annotation when retain is false
+    template: pvc-data.yaml
+    set:
+      persistence.data.retain: false
+    asserts:
+      - notExists:
+          path: metadata.annotations["helm.sh/resource-policy"]
+
+  - it: should set a storage class when provided
+    template: pvc-media.yaml
+    set:
+      persistence.media.storageClassName: fast-ssd
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: fast-ssd

--- a/charts/obico/tests/redis_test.yaml
+++ b/charts/obico/tests/redis_test.yaml
@@ -1,0 +1,71 @@
+suite: test bundled redis
+templates:
+  - redis.yaml
+tests:
+  - it: should create redis Deployment and Service by default
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should not create redis when disabled
+    set:
+      redis.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a redis Deployment
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-redis
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: redis:7.2-alpine
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: redis
+            containerPort: 6379
+            protocol: TCP
+
+  - it: should label the redis pod with its component
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: redis
+
+  - it: should not automount the service account token
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should create a redis Service
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-redis
+      - equal:
+          path: spec.ports[0].port
+          value: 6379
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: redis
+
+  - it: should allow a custom redis image tag
+    documentIndex: 0
+    set:
+      redis.image.tag: "7.4-alpine"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: redis:7.4-alpine

--- a/charts/obico/tests/secret_test.yaml
+++ b/charts/obico/tests/secret_test.yaml
@@ -1,0 +1,39 @@
+suite: test secret
+templates:
+  - secret.yaml
+tests:
+  - it: should create a Secret with a Django secret key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico
+      - isNotEmpty:
+          path: stringData.DJANGO_SECRET_KEY
+
+  - it: should use the provided secret key
+    set:
+      obico.secretKey: my-fixed-key
+    asserts:
+      - equal:
+          path: stringData.DJANGO_SECRET_KEY
+          value: my-fixed-key
+
+  - it: should merge extra secret env
+    set:
+      obico.extraSecretEnv:
+        EMAIL_HOST_PASSWORD: s3cr3t
+    asserts:
+      - equal:
+          path: stringData.EMAIL_HOST_PASSWORD
+          value: s3cr3t
+
+  - it: should not render a Secret when existingSecret is set
+    set:
+      obico.existingSecret: obico-secrets
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/obico/tests/service_test.yaml
+++ b/charts/obico/tests/service_test.yaml
@@ -1,0 +1,84 @@
+suite: test services
+templates:
+  - service.yaml
+tests:
+  - it: should create web and ml-api services by default
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: should create the web service
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-web
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 3334
+            targetPort: http
+            protocol: TCP
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: web
+
+  - it: should create the ml-api service
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-ml-api
+      - contains:
+          path: spec.ports
+          content:
+            name: http
+            port: 3333
+            targetPort: http
+            protocol: TCP
+      - equal:
+          path: spec.selector["app.kubernetes.io/component"]
+          value: ml-api
+
+  - it: should not create the ml-api service when ml-api disabled
+    set:
+      mlApi.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico-web
+
+  - it: should support a custom web port
+    documentIndex: 0
+    set:
+      service.web.port: 8080
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 8080
+
+  - it: should have no annotations by default on the web service
+    documentIndex: 0
+    asserts:
+      - notExists:
+          path: metadata.annotations
+
+  - it: should support custom annotations on the web service
+    documentIndex: 0
+    set:
+      service.web.annotations:
+        custom.annotation/key: "value"
+    asserts:
+      - equal:
+          path: metadata.annotations["custom.annotation/key"]
+          value: "value"

--- a/charts/obico/tests/serviceaccount_test.yaml
+++ b/charts/obico/tests/serviceaccount_test.yaml
@@ -1,0 +1,37 @@
+suite: test service account
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should create a ServiceAccount by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-obico
+
+  - it: should not create a ServiceAccount when create is false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should use a custom service account name
+    set:
+      serviceAccount.name: my-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-sa
+
+  - it: should apply custom annotations
+    set:
+      serviceAccount.annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::123:role/obico
+    asserts:
+      - equal:
+          path: metadata.annotations["eks.amazonaws.com/role-arn"]
+          value: arn:aws:iam::123:role/obico

--- a/charts/obico/values.schema.json
+++ b/charts/obico/values.schema.json
@@ -1,0 +1,551 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Obico Values",
+  "type": "object",
+  "properties": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "web": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Web image repository"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "description": "Web image pull policy"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Overrides the web image tag whose default is the chart appVersion"
+            }
+          },
+          "required": ["repository", "pullPolicy"]
+        },
+        "mlApi": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "ML API image repository"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "description": "ML API image pull policy"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Overrides the ml-api image tag whose default is the chart appVersion"
+            }
+          },
+          "required": ["repository", "pullPolicy"]
+        }
+      },
+      "required": ["web", "mlApi"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Image pull secrets"
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the fullname of the chart"
+    },
+    "obico": {
+      "type": "object",
+      "properties": {
+        "debug": {
+          "type": "boolean",
+          "description": "Enable Django debug mode"
+        },
+        "siteUsesHttps": {
+          "type": "boolean",
+          "description": "Set true when served over HTTPS"
+        },
+        "csrfTrustedOrigins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "CSRF trusted origins; auto-derived from ingress/httpRoute when empty"
+        },
+        "secretKey": {
+          "type": "string",
+          "description": "Django SECRET_KEY (set explicitly for GitOps; empty regenerates on render-only paths)"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Pre-created Secret holding DJANGO_SECRET_KEY and other sensitive env"
+        },
+        "extraEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra non-sensitive environment variables (string key-value pairs)"
+        },
+        "extraSecretEnv": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Extra sensitive environment variables (string key-value pairs)"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "Django DATABASE_URL connection string"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Existing Secret holding DATABASE_URL"
+        },
+        "existingSecretKey": {
+          "type": "string",
+          "description": "Key in existingSecret holding DATABASE_URL"
+        }
+      }
+    },
+    "web": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Command for the Daphne ASGI server"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    },
+    "tasks": {
+      "type": "object",
+      "properties": {
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Command for the Celery worker"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      }
+    },
+    "mlApi": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy the ML inference API"
+        },
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of ml-api replicas"
+        },
+        "command": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Command for the gunicorn inference server"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for the ml-api container"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Deploy a bundled in-cluster Redis"
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string",
+              "description": "Redis image repository"
+            },
+            "tag": {
+              "type": "string",
+              "description": "Redis image tag"
+            },
+            "pullPolicy": {
+              "type": "string",
+              "enum": ["Always", "IfNotPresent", "Never"],
+              "description": "Redis image pull policy"
+            }
+          },
+          "required": ["repository", "tag"]
+        },
+        "externalUrl": {
+          "type": "string",
+          "description": "External Redis URL used when redis.enabled is false"
+        },
+        "securityContext": {
+          "type": "object",
+          "description": "Security context for the redis container"
+        },
+        "resources": {
+          "$ref": "#/definitions/resources"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "web": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+              "description": "Service type for the web UI"
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "description": "Web HTTP port"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations for the web service (must be string key-value pairs)"
+            }
+          },
+          "required": ["type", "port"]
+        },
+        "mlApi": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+              "description": "Service type for the ml-api"
+            },
+            "port": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535,
+              "description": "ML API HTTP port"
+            },
+            "annotations": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Annotations for the ml-api service (must be string key-value pairs)"
+            }
+          },
+          "required": ["type", "port"]
+        }
+      },
+      "required": ["web", "mlApi"]
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ingress"
+        },
+        "className": {
+          "type": "string",
+          "description": "Ingress class name"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Ingress annotations (must be string key-value pairs)"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "Hostname"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Prefix", "Exact", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": ["enabled"]
+    },
+    "httpRoute": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable HTTPRoute (Gateway API)"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "HTTPRoute annotations (must be string key-value pairs)"
+        },
+        "parentRefs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Gateway name"
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Gateway namespace"
+              },
+              "sectionName": {
+                "type": "string",
+                "description": "Optional: specific listener on the Gateway"
+              }
+            }
+          },
+          "description": "Parent Gateway references"
+        },
+        "hostnames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Hostnames for the route"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "matches": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "filters": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "weight": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 1000000
+              }
+            }
+          },
+          "description": "Routing rules"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "persistence": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/volume"
+        },
+        "media": {
+          "$ref": "#/definitions/volume"
+        }
+      },
+      "required": ["data", "media"]
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the pod"
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context for the server, tasks and migrate containers"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Pod annotations (must be string key-value pairs)"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Pod labels"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a service account should be created"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the service account (must be string key-value pairs)"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the service account to use"
+        }
+      },
+      "required": ["create"]
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Tolerations"
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules"
+    }
+  },
+  "required": ["image", "service", "persistence", "redis", "mlApi"],
+  "definitions": {
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$",
+              "description": "Memory request"
+            },
+            "cpu": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?m?$",
+              "description": "CPU request"
+            }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$",
+              "description": "Memory limit"
+            },
+            "cpu": {
+              "type": "string",
+              "pattern": "^[0-9]+(\\.[0-9]+)?m?$",
+              "description": "CPU limit"
+            }
+          }
+        }
+      }
+    },
+    "volume": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable this volume"
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "Storage class name"
+        },
+        "accessMode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"],
+          "description": "Access mode"
+        },
+        "size": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(Ki|Mi|Gi|Ti|Pi|Ei|K|M|G|T|P|E)?$",
+          "description": "Size of the volume"
+        },
+        "existingClaim": {
+          "type": "string",
+          "description": "Use an existing PVC"
+        },
+        "retain": {
+          "type": "boolean",
+          "description": "Keep the PVC on uninstall"
+        }
+      },
+      "required": ["enabled"]
+    }
+  }
+}

--- a/charts/obico/values.yaml
+++ b/charts/obico/values.yaml
@@ -1,0 +1,289 @@
+# Default values for obico
+# Obico is a multi-service Django stack: a web app (Daphne/ASGI), a Celery
+# worker, an ML inference API and Redis. The web and tasks containers share a
+# single pod so they can share the SQLite database on a ReadWriteOnce volume.
+
+# -- Container images. Built from obico-server source and published to GHCR.
+# Both images share the chart appVersion tag (one obico commit -> one tag).
+image:
+  # -- Web application image (Django + Celery)
+  web:
+    repository: ghcr.io/lexfrei/obico-web
+    pullPolicy: IfNotPresent
+    # -- Overrides the image tag whose default is the chart appVersion
+    tag: ""
+  # -- ML inference API image (failure detection)
+  mlApi:
+    repository: ghcr.io/lexfrei/obico-ml-api
+    pullPolicy: IfNotPresent
+    # -- Overrides the image tag whose default is the chart appVersion
+    tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Obico application configuration (rendered into the env ConfigMap/Secret)
+obico:
+  # -- Enable Django debug mode (never enable in production)
+  debug: false
+  # -- Set to true when the site is served over HTTPS (behind a TLS ingress/gateway)
+  siteUsesHttps: false
+  # -- CSRF trusted origins (Django 4+ rejects HTTPS POSTs from untrusted origins).
+  # Leave empty to auto-derive from the enabled ingress hosts / HTTPRoute
+  # hostnames using the scheme implied by siteUsesHttps. Set explicitly to
+  # override, e.g. ["https://obico.example.com"].
+  csrfTrustedOrigins: []
+  # -- Django SECRET_KEY.
+  # IMPORTANT: leave empty only for a quick `helm install` test. The empty-value
+  # fallback reuses the live Secret on upgrades but REGENERATES the key on any
+  # render-only path (helm template, --dry-run, helm diff, ArgoCD) — rotating it
+  # logs every user out and rolls the pod on every sync. For GitOps set a stable
+  # value here (e.g. `openssl rand -base64 48`) or use existingSecret below.
+  secretKey: ""
+  # -- Reference a pre-created Secret for sensitive env (must contain
+  # DJANGO_SECRET_KEY and any other secret keys). When set, the chart does not
+  # create its own Secret and extraSecretEnv is ignored. Recommended for GitOps.
+  existingSecret: ""
+  # -- Extra non-sensitive environment variables (key/value) for web and tasks.
+  # Chart-managed keys (DATABASE_URL, REDIS_URL, ...) are rejected here.
+  # Example: EMAIL_HOST: smtp.example.com
+  extraEnv: {}
+  # -- Extra sensitive environment variables (key/value) stored in the Secret.
+  # Example: EMAIL_HOST_PASSWORD: s3cr3t
+  extraSecretEnv: {}
+
+# -- Database configuration. Defaults to SQLite on the data volume.
+# WARNING: SQLite is for evaluation only. The server and the Celery worker run
+# as separate processes writing the same file, so under load they will hit
+# "database is locked" errors. Upstream ships PostgreSQL only. For any real use
+# set url to an external postgresql:// DSN, or reference a Secret via
+# existingSecret/existingSecretKey.
+database:
+  # -- Database connection string (Django DATABASE_URL)
+  url: "sqlite:////data/db.sqlite3"
+  # -- Use a key from an existing Secret for DATABASE_URL instead of url
+  existingSecret: ""
+  # -- Key inside existingSecret holding the DATABASE_URL value
+  existingSecretKey: "DATABASE_URL"
+
+# -- Web pod configuration (server + tasks containers, plus init containers)
+web:
+  # -- Command for the Daphne ASGI server (serves API, frontend and websockets)
+  command:
+    - daphne
+    - -b
+    - 0.0.0.0
+    - -p
+    - "3334"
+    - config.routing:application
+  # -- Resource requests/limits for the server container
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "250m"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
+
+# -- Celery worker (runs in the same pod as the web server)
+tasks:
+  # -- Command for the Celery worker with beat scheduler
+  command:
+    - celery
+    - -A
+    - config
+    - worker
+    - --beat
+    - -l
+    - info
+    - -c
+    - "2"
+    - -Q
+    - realtime,celery
+  # -- Resource requests/limits for the tasks container
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+# -- ML inference API (AI failure detection). Heavy image; can be disabled.
+mlApi:
+  # -- Deploy the ML inference API
+  enabled: true
+  # -- Number of ml-api replicas
+  replicaCount: 1
+  # -- Command for the gunicorn inference server
+  command:
+    - gunicorn
+    - --bind=0.0.0.0:3333
+    - --workers=1
+    - --access-logfile=-
+    - wsgi
+  # -- Security context for the ml-api container.
+  # Left empty (image default = root) because the upstream CUDA-based ml-api
+  # image is not validated to run unprivileged (model cache and runtime expect
+  # root). Harden here once confirmed it runs as non-root in your environment.
+  securityContext: {}
+  # -- Resource requests/limits for the ml-api container
+  resources:
+    requests:
+      memory: "1Gi"
+      cpu: "500m"
+    limits:
+      memory: "2Gi"
+      cpu: "2"
+
+# -- Bundled Redis (Celery broker + Django Channels + cache)
+redis:
+  # -- Deploy a minimal in-cluster Redis. Disable to use an external Redis.
+  enabled: true
+  # -- Redis image (pinned; not tied to the chart appVersion)
+  image:
+    repository: redis
+    # renovate: datasource=docker depName=redis
+    tag: "7.2-alpine"
+    pullPolicy: IfNotPresent
+  # -- External Redis URL, used when redis.enabled is false
+  externalUrl: ""
+  # -- Security context for the redis container
+  securityContext:
+    runAsUser: 999
+    runAsNonRoot: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  # -- Resource requests/limits for the redis container
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "256Mi"
+      cpu: "200m"
+
+# -- Service configuration
+service:
+  # -- Web UI / API service (ClusterIP for Ingress/HTTPRoute)
+  web:
+    # -- Service type for the web UI
+    type: ClusterIP
+    # -- HTTP port
+    port: 3334
+    # -- Annotations for the web service
+    annotations: {}
+  # -- ML inference API service (internal)
+  mlApi:
+    # -- Service type for the ml-api
+    type: ClusterIP
+    # -- HTTP port
+    port: 3333
+    # -- Annotations for the ml-api service
+    annotations: {}
+
+# -- Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: obico.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: obico-tls
+      hosts:
+        - obico.example.com
+
+# -- HTTPRoute configuration (Gateway API)
+httpRoute:
+  enabled: false
+  annotations: {}
+  # -- Parent Gateway references
+  parentRefs:
+    - name: gateway
+      namespace: gateway-system
+      # sectionName: https-listener  # Optional: specific listener on the Gateway
+  # -- Hostnames for the route
+  hostnames:
+    - obico.example.com
+  # -- Routing rules
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+# -- Persistence configuration
+persistence:
+  # -- Data volume (SQLite database and persistent data)
+  data:
+    enabled: true
+    # -- Storage class name
+    storageClassName: ""
+    # -- Access mode
+    accessMode: ReadWriteOnce
+    # -- Size of the volume
+    size: 1Gi
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Keep the PVC when the release is uninstalled
+    retain: true
+  # -- Media volume (user uploads, webcam frames, timelapses)
+  media:
+    enabled: true
+    # -- Storage class name
+    storageClassName: ""
+    # -- Access mode
+    accessMode: ReadWriteOnce
+    # -- Size of the volume
+    size: 10Gi
+    # -- Use an existing PVC instead of creating one
+    existingClaim: ""
+    # -- Keep the PVC when the release is uninstalled
+    retain: true
+
+# -- Security context for the pod.
+# fsGroup is load-bearing, not cosmetic: the server, tasks and migrate
+# containers run as non-root (65534, see securityContext below), so the data
+# and media volumes must be group-owned by that gid for them to write the
+# SQLite DB and media files. It also lets the non-root server read the static
+# assets generated by the root collectstatic init container. Keep them aligned.
+podSecurityContext:
+  fsGroup: 65534
+
+# -- Security context for the server, tasks and migrate containers
+securityContext:
+  runAsUser: 65534
+  runAsGroup: 65534
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Service account configuration
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use
+  name: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Description

Add a Helm chart for the Obico server (formerly The Spaghetti Detective) — a self-hosted server for AI-powered 3D-printer monitoring on OctoPrint/Klipper. The chart deploys the full stack: the Django web app (Daphne) and the Celery worker share one pod so they can share a SQLite database on a ReadWriteOnce volume; the ML inference API and a bundled Redis run as separate workloads. It supports both classic Ingress and Gateway API HTTPRoute, defaults to SQLite for a zero-dependency install with a documented external-PostgreSQL path, and derives CSRF_TRUSTED_ORIGINS automatically from the configured hostnames.

Obico does not publish ready-to-run images, so the chart consumes images built from source in a separate repository (lexfrei/images) and tracks them by appVersion (CalVer) so Renovate can bump the chart automatically.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version set in `Chart.yaml` (initial release 0.1.0)
- [x] `Chart.yaml` annotations updated with changelog entries (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated
- [x] `README.md` has been generated from the template
- [x] All new values have proper descriptions/comments
- [x] Tests have been added in `tests/` directory (102 unit tests)
- [x] All tests pass locally (`helm unittest charts/obico`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/obico/values.schema.json charts/obico/values.yaml`)
- [x] Helm lint passes (`helm lint charts/obico`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

## Additional context

The `SECRET_KEY` auto-generation fallback regenerates the key on render-only paths (helm template / --dry-run / ArgoCD); this is documented in `values.yaml` and the README, and the GitOps-safe paths (explicit `obico.secretKey` or `obico.existingSecret`) are wired and tested. SQLite is documented as evaluation-only because the web and Celery processes share the database file and can hit `database is locked` under load.
