### PR TITLE
feat(obico): compose DATABASE_URL from parts for connection poolers

### DIFF
--- a/charts/obico/Chart.yaml
+++ b/charts/obico/Chart.yaml
@@ -3,8 +3,8 @@ annotations:
   # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
   # See: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update bundled Redis image to 8.8-alpine
+    - kind: added
+      description: Compose DATABASE_URL from host/port/name/user with the password sourced from a Secret, for pointing Obico at a connection pooler (e.g. CloudNativePG Pooler / PgBouncer)
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -20,7 +20,7 @@ apiVersion: v2
 name: obico
 description: Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper)
 type: application
-version: "0.1.3"
+version: "0.2.0"
 # renovate: datasource=docker depName=ghcr.io/lexfrei/obico-web
 # CalVer derived from the obico-server release commit date (see lexfrei/images).
 appVersion: "2026.1.20"

--- a/charts/obico/README.md
+++ b/charts/obico/README.md
@@ -1,6 +1,6 @@
 # obico
 
-![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.20](https://img.shields.io/badge/AppVersion-2026.1.20-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.20](https://img.shields.io/badge/AppVersion-2026.1.20-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -55,12 +55,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install obico \
   oci://ghcr.io/lexfrei/charts/obico \
-  --version 0.1.3
+  --version 0.2.0
 
 # Install with custom values
 helm install obico \
   oci://ghcr.io/lexfrei/charts/obico \
-  --version 0.1.3 \
+  --version 0.2.0 \
   --values values.yaml
 ```
 
@@ -70,7 +70,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/obico:0.1.3 \
+  ghcr.io/lexfrei/charts/obico:0.2.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -104,7 +104,7 @@ obico:
 
 ## Database
 
-The default configuration uses SQLite on the data volume so the chart installs with no external dependencies. **SQLite is for evaluation only:** the web server and the Celery worker are separate processes writing the same database file, so under real load they hit `database is locked` errors. Upstream Obico ships PostgreSQL only. For anything beyond a quick try-out, point `database.url` at an external PostgreSQL, or reference a Secret:
+The default configuration uses SQLite on the data volume so the chart installs with no external dependencies. **SQLite is for evaluation only:** the web server and the Celery worker are separate processes writing the same database file, so under real load they hit `database is locked` errors. Upstream Obico ships PostgreSQL only. For anything beyond a quick try-out, point `database.url` at an external PostgreSQL, reference a Secret holding the full DSN, or compose the DSN from parts with the password kept in a Secret:
 
 ```yaml
 # Plain connection string
@@ -117,6 +117,20 @@ database:
 database:
   existingSecret: obico-db
   existingSecretKey: DATABASE_URL
+```
+
+```yaml
+# Compose the DSN from parts, with the password kept in a Secret. Point host at a
+# connection pooler (e.g. a CloudNativePG Pooler / PgBouncer) to multiplex many
+# app connections onto a few server connections. Mutually exclusive with
+# existingSecret; the password is used verbatim and must be URL-safe.
+database:
+  host: obico-db-pooler
+  port: 5432
+  name: obico
+  user: obico
+  passwordSecret: obico-db-app
+  passwordSecretKey: password
 ```
 
 ## Exposing the Web UI
@@ -177,10 +191,16 @@ The trade-off is size: the CUDA layers make the `ml-api` image large (~3 GB comp
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| database | object | `{"existingSecret":"","existingSecretKey":"DATABASE_URL","url":"sqlite:////data/db.sqlite3"}` | Database configuration. Defaults to SQLite on the data volume. WARNING: SQLite is for evaluation only. The server and the Celery worker run as separate processes writing the same file, so under load they will hit "database is locked" errors. Upstream ships PostgreSQL only. For any real use set url to an external postgresql:// DSN, or reference a Secret via existingSecret/existingSecretKey. |
-| database.existingSecret | string | `""` | Use a key from an existing Secret for DATABASE_URL instead of url |
+| database | object | `{"existingSecret":"","existingSecretKey":"DATABASE_URL","host":"","name":"","passwordSecret":"","passwordSecretKey":"password","port":5432,"url":"sqlite:////data/db.sqlite3","user":""}` | Database configuration. Defaults to SQLite on the data volume. WARNING: SQLite is for evaluation only. The server and the Celery worker run as separate processes writing the same file, so under load they will hit "database is locked" errors. Upstream ships PostgreSQL only. For any real use set url to an external postgresql:// DSN, or reference a Secret via existingSecret/existingSecretKey. |
+| database.existingSecret | string | `""` | Use a key from an existing Secret for the full DATABASE_URL instead of url |
 | database.existingSecretKey | string | `"DATABASE_URL"` | Key inside existingSecret holding the DATABASE_URL value |
-| database.url | string | `"sqlite:////data/db.sqlite3"` | Database connection string (Django DATABASE_URL) |
+| database.host | string | `""` | PostgreSQL host. When set, DATABASE_URL is composed from the fields below and the password is injected from passwordSecret at runtime (so it never lands in the ConfigMap or in git). Mutually exclusive with existingSecret. Point this at a connection pooler service (e.g. a CloudNativePG Pooler / PgBouncer) to multiplex many app connections onto few server connections. The password must be URL-safe; the chart does not URL-encode it. |
+| database.name | string | `""` | PostgreSQL database name (compose mode; required when host is set) |
+| database.passwordSecret | string | `""` | Name of an existing Secret holding the PostgreSQL password (compose mode; required when host is set) |
+| database.passwordSecretKey | string | `"password"` | Key inside passwordSecret holding the password |
+| database.port | int | `5432` | PostgreSQL port (compose mode) |
+| database.url | string | `"sqlite:////data/db.sqlite3"` | Database connection string (Django DATABASE_URL). Used only when neither existingSecret nor host is set. |
+| database.user | string | `""` | PostgreSQL user (compose mode; required when host is set) |
 | fullnameOverride | string | `""` |  |
 | httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":["obico.example.com"],"parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | HTTPRoute configuration (Gateway API) |
 | httpRoute.hostnames | list | `["obico.example.com"]` | Hostnames for the route |

--- a/charts/obico/README.md.gotmpl
+++ b/charts/obico/README.md.gotmpl
@@ -96,7 +96,7 @@ obico:
 
 ## Database
 
-The default configuration uses SQLite on the data volume so the chart installs with no external dependencies. **SQLite is for evaluation only:** the web server and the Celery worker are separate processes writing the same database file, so under real load they hit `database is locked` errors. Upstream Obico ships PostgreSQL only. For anything beyond a quick try-out, point `database.url` at an external PostgreSQL, or reference a Secret:
+The default configuration uses SQLite on the data volume so the chart installs with no external dependencies. **SQLite is for evaluation only:** the web server and the Celery worker are separate processes writing the same database file, so under real load they hit `database is locked` errors. Upstream Obico ships PostgreSQL only. For anything beyond a quick try-out, point `database.url` at an external PostgreSQL, reference a Secret holding the full DSN, or compose the DSN from parts with the password kept in a Secret:
 
 ```yaml
 # Plain connection string
@@ -109,6 +109,20 @@ database:
 database:
   existingSecret: obico-db
   existingSecretKey: DATABASE_URL
+```
+
+```yaml
+# Compose the DSN from parts, with the password kept in a Secret. Point host at a
+# connection pooler (e.g. a CloudNativePG Pooler / PgBouncer) to multiplex many
+# app connections onto a few server connections. Mutually exclusive with
+# existingSecret; the password is used verbatim and must be URL-safe.
+database:
+  host: obico-db-pooler
+  port: 5432
+  name: obico
+  user: obico
+  passwordSecret: obico-db-app
+  passwordSecretKey: password
 ```
 
 ## Exposing the Web UI

--- a/charts/obico/templates/NOTES.txt
+++ b/charts/obico/templates/NOTES.txt
@@ -14,7 +14,7 @@ Components:
   - redis (bundled)
   {{- end }}
 
-Database: {{ if .Values.database.existingSecret }}external (from secret {{ .Values.database.existingSecret }}){{ else }}{{ .Values.database.url }}{{ end }}
+Database: {{ if .Values.database.existingSecret }}external (full DSN from secret {{ .Values.database.existingSecret }}){{ else if .Values.database.host }}postgresql://{{ .Values.database.user }}@{{ .Values.database.host }}:{{ .Values.database.port }}/{{ .Values.database.name }} (password from secret {{ .Values.database.passwordSecret }}){{ else }}{{ .Values.database.url }}{{ end }}
 
 To check the status of your deployment:
 

--- a/charts/obico/templates/_helpers.tpl
+++ b/charts/obico/templates/_helpers.tpl
@@ -156,7 +156,42 @@ env:
       secretKeyRef:
         name: {{ .Values.database.existingSecret }}
         key: {{ .Values.database.existingSecretKey }}
+{{- else if .Values.database.host }}
+env:
+  # OBICO_DB_PASSWORD is read from the Secret, then referenced via the $(VAR)
+  # dependent-env syntax so the password is assembled into DATABASE_URL at
+  # runtime instead of being baked into the ConfigMap. Kubernetes only expands
+  # $(VAR) for vars declared earlier in the same container's env list.
+  - name: OBICO_DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: {{ .Values.database.passwordSecret }}
+        key: {{ .Values.database.passwordSecretKey }}
+  - name: DATABASE_URL
+    value: {{ printf "postgresql://%s:$(OBICO_DB_PASSWORD)@%s:%v/%s" .Values.database.user .Values.database.host .Values.database.port .Values.database.name | quote }}
 {{- end }}
+{{- end }}
+
+{{/*
+Validate the database configuration. existingSecret (full DSN from a Secret) and
+host (DATABASE_URL composed from parts) are mutually exclusive; compose mode
+requires user, name and passwordSecret. Rendered once from configmap.yaml.
+*/}}
+{{- define "obico.validateDatabase" -}}
+{{- if and .Values.database.existingSecret .Values.database.host -}}
+{{- fail "database.existingSecret and database.host are mutually exclusive: set one or the other" -}}
+{{- end -}}
+{{- if .Values.database.host -}}
+{{- if not .Values.database.user -}}
+{{- fail "database.host is set: database.user is required to compose DATABASE_URL" -}}
+{{- end -}}
+{{- if not .Values.database.name -}}
+{{- fail "database.host is set: database.name is required to compose DATABASE_URL" -}}
+{{- end -}}
+{{- if not .Values.database.passwordSecret -}}
+{{- fail "database.host is set: database.passwordSecret is required to source the password" -}}
+{{- end -}}
+{{- end -}}
 {{- end }}
 
 {{/*
@@ -165,7 +200,7 @@ free-form extraEnv / extraSecretEnv maps, which would silently win via
 later-key YAML semantics in the ConfigMap / Secret.
 */}}
 {{- define "obico.checkReservedEnv" -}}
-{{- $reserved := list "DEBUG" "WEBPACK_LOADER_ENABLED" "SITE_USES_HTTPS" "REDIS_URL" "ML_API_HOST" "INTERNAL_MEDIA_HOST" "DATABASE_URL" "DJANGO_SECRET_KEY" "CSRF_TRUSTED_ORIGINS" -}}
+{{- $reserved := list "DEBUG" "WEBPACK_LOADER_ENABLED" "SITE_USES_HTTPS" "REDIS_URL" "ML_API_HOST" "INTERNAL_MEDIA_HOST" "DATABASE_URL" "OBICO_DB_PASSWORD" "DJANGO_SECRET_KEY" "CSRF_TRUSTED_ORIGINS" -}}
 {{- range $key, $_ := .Values.obico.extraEnv -}}
 {{- if has $key $reserved -}}
 {{- fail (printf "obico.extraEnv must not set the chart-managed key %q; configure it via its dedicated value instead" $key) -}}

--- a/charts/obico/templates/configmap.yaml
+++ b/charts/obico/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- include "obico.checkReservedEnv" . -}}
+{{- include "obico.validateDatabase" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,7 +16,7 @@ data:
   ML_API_HOST: {{ printf "http://%s-ml-api:%v" (include "obico.fullname" .) .Values.service.mlApi.port | quote }}
   {{- end }}
   INTERNAL_MEDIA_HOST: {{ printf "http://%s-web:%v" (include "obico.fullname" .) .Values.service.web.port | quote }}
-  {{- if not .Values.database.existingSecret }}
+  {{- if and (not .Values.database.existingSecret) (not .Values.database.host) }}
   DATABASE_URL: {{ .Values.database.url | quote }}
   {{- end }}
   {{- range $key, $value := .Values.obico.extraEnv }}

--- a/charts/obico/tests/configmap_test.yaml
+++ b/charts/obico/tests/configmap_test.yaml
@@ -92,6 +92,51 @@ tests:
       - notExists:
           path: data.DATABASE_URL
 
+  - it: should not set DATABASE_URL in the ConfigMap when composing from host
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.name: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - notExists:
+          path: data.DATABASE_URL
+
+  - it: should reject setting both existingSecret and host
+    set:
+      database.existingSecret: my-db-secret
+      database.host: obico-db-pooler
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.existingSecret and database.host are mutually exclusive: set one or the other"
+
+  - it: should require user when composing from host
+    set:
+      database.host: obico-db-pooler
+      database.name: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.host is set: database.user is required to compose DATABASE_URL"
+
+  - it: should require name when composing from host
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.host is set: database.name is required to compose DATABASE_URL"
+
+  - it: should require passwordSecret when composing from host
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.name: obico
+    asserts:
+      - failedTemplate:
+          errorMessage: "database.host is set: database.passwordSecret is required to source the password"
+
   - it: should default CSRF_TRUSTED_ORIGINS to an empty list
     asserts:
       - equal:
@@ -155,3 +200,11 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: 'obico.extraSecretEnv must not set the chart-managed key "DJANGO_SECRET_KEY"; configure it via its dedicated value instead'
+
+  - it: should reject the compose-mode password key in extraEnv
+    set:
+      obico.extraEnv:
+        OBICO_DB_PASSWORD: hunter2
+    asserts:
+      - failedTemplate:
+          errorMessage: 'obico.extraEnv must not set the chart-managed key "OBICO_DB_PASSWORD"; configure it via its dedicated value instead'

--- a/charts/obico/tests/deployment_web_test.yaml
+++ b/charts/obico/tests/deployment_web_test.yaml
@@ -222,6 +222,54 @@ tests:
                 name: my-db-secret
                 key: DATABASE_URL
 
+  - it: should compose DATABASE_URL and inject the password env in compose mode
+    template: deployment-web.yaml
+    set:
+      database.host: obico-db-pooler
+      database.port: 5432
+      database.user: obico
+      database.name: obico
+      database.passwordSecret: obico-db-app
+      database.passwordSecretKey: password
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OBICO_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: obico-db-app
+                key: password
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://obico:$(OBICO_DB_PASSWORD)@obico-db-pooler:5432/obico"
+
+  - it: should inject the composed DATABASE_URL into collectstatic, migrate and tasks
+    template: deployment-web.yaml
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.name: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://obico:$(OBICO_DB_PASSWORD)@obico-db-pooler:5432/obico"
+      - contains:
+          path: spec.template.spec.initContainers[1].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://obico:$(OBICO_DB_PASSWORD)@obico-db-pooler:5432/obico"
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: DATABASE_URL
+            value: "postgresql://obico:$(OBICO_DB_PASSWORD)@obico-db-pooler:5432/obico"
+
   - it: should reference the existing secret in envFrom when obico.existingSecret is set
     template: deployment-web.yaml
     set:

--- a/charts/obico/tests/notes_test.yaml
+++ b/charts/obico/tests/notes_test.yaml
@@ -1,0 +1,25 @@
+suite: test NOTES output
+templates:
+  - NOTES.txt
+tests:
+  - it: should report the SQLite default in NOTES
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Database: sqlite:////data/db\.sqlite3'
+
+  - it: should report an existingSecret database in NOTES
+    set:
+      database.existingSecret: obico-db
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Database: external \(full DSN from secret obico-db\)'
+
+  - it: should report the composed database in NOTES
+    set:
+      database.host: obico-db-pooler
+      database.user: obico
+      database.name: obico
+      database.passwordSecret: obico-db-app
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Database: postgresql://obico@obico-db-pooler:5432/obico \(password from secret obico-db-app\)'

--- a/charts/obico/values.schema.json
+++ b/charts/obico/values.schema.json
@@ -118,6 +118,30 @@
         "existingSecretKey": {
           "type": "string",
           "description": "Key in existingSecret holding DATABASE_URL"
+        },
+        "host": {
+          "type": "string",
+          "description": "PostgreSQL host; when set, DATABASE_URL is composed from the fields below (mutually exclusive with existingSecret)"
+        },
+        "port": {
+          "type": "integer",
+          "description": "PostgreSQL port (compose mode)"
+        },
+        "name": {
+          "type": "string",
+          "description": "PostgreSQL database name (compose mode)"
+        },
+        "user": {
+          "type": "string",
+          "description": "PostgreSQL user (compose mode)"
+        },
+        "passwordSecret": {
+          "type": "string",
+          "description": "Existing Secret holding the PostgreSQL password (compose mode)"
+        },
+        "passwordSecretKey": {
+          "type": "string",
+          "description": "Key in passwordSecret holding the password"
         }
       }
     },

--- a/charts/obico/values.yaml
+++ b/charts/obico/values.yaml
@@ -60,12 +60,31 @@ obico:
 # set url to an external postgresql:// DSN, or reference a Secret via
 # existingSecret/existingSecretKey.
 database:
-  # -- Database connection string (Django DATABASE_URL)
+  # -- Database connection string (Django DATABASE_URL). Used only when neither
+  # existingSecret nor host is set.
   url: "sqlite:////data/db.sqlite3"
-  # -- Use a key from an existing Secret for DATABASE_URL instead of url
+  # -- Use a key from an existing Secret for the full DATABASE_URL instead of url
   existingSecret: ""
   # -- Key inside existingSecret holding the DATABASE_URL value
   existingSecretKey: "DATABASE_URL"
+  # -- PostgreSQL host. When set, DATABASE_URL is composed from the fields below
+  # and the password is injected from passwordSecret at runtime (so it never
+  # lands in the ConfigMap or in git). Mutually exclusive with existingSecret.
+  # Point this at a connection pooler service (e.g. a CloudNativePG Pooler /
+  # PgBouncer) to multiplex many app connections onto few server connections.
+  # The password must be URL-safe; the chart does not URL-encode it.
+  host: ""
+  # -- PostgreSQL port (compose mode)
+  port: 5432
+  # -- PostgreSQL database name (compose mode; required when host is set)
+  name: ""
+  # -- PostgreSQL user (compose mode; required when host is set)
+  user: ""
+  # -- Name of an existing Secret holding the PostgreSQL password (compose mode;
+  # required when host is set)
+  passwordSecret: ""
+  # -- Key inside passwordSecret holding the password
+  passwordSecretKey: "password"
 
 # -- Web pod configuration (server + tasks containers, plus init containers)
 web:


### PR DESCRIPTION
## Description

Add a third database configuration mode to the obico chart. Alongside the plaintext `database.url` and the full-DSN `database.existingSecret`, setting `database.host` composes `DATABASE_URL` from `host`/`port`/`name`/`user` with the password injected from `passwordSecret` at container start via the `$(VAR)` dependent-env syntax. The password never lands in the ConfigMap or in committed values. This lets the server point at a connection pooler (e.g. a CloudNativePG Pooler / PgBouncer service) while still sourcing the database password from its managed Secret. `existingSecret` and `host` are mutually exclusive; compose mode requires `user`, `name` and `passwordSecret`, enforced by a render-time validation. The password is used verbatim and must be URL-safe.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml` (0.1.3 → 0.2.0)
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated
- [x] `README.md` has been updated (regenerated from `README.md.gotmpl`)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/obico` — 113 passed)
- [x] Schema validation passes (`check-jsonschema`)
- [x] Helm lint passes (`ct lint`)

### If modifying existing functionality

- [x] Changes are backward compatible
- [x] Default values maintain existing behavior (SQLite default unchanged)

## Additional context

`OBICO_DB_PASSWORD`, the intermediate env var used to assemble the DSN, is added to the reserved-env guard so it cannot be silently shadowed via `extraEnv`/`extraSecretEnv`. The password is used verbatim (not URL-encoded), which is documented in `values.yaml`, the schema and the README.
