### PR TITLE
feat(spoolman): add Spoolman Helm chart

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,6 +9,11 @@ body:
       description: Which chart is affected?
       options:
         - cloudflare-tunnel
+        - eclipse-edc
+        - extractedprism
+        - me-site
+        - obico
+        - spoolman
         - system-upgrade-controller
         - transmission
         - vipalived

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,6 +9,11 @@ body:
       description: Which chart should this feature be added to?
       options:
         - cloudflare-tunnel
+        - eclipse-edc
+        - extractedprism
+        - me-site
+        - obico
+        - spoolman
         - system-upgrade-controller
         - transmission
         - vipalived

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -9,6 +9,11 @@ body:
       description: Which chart is your question about?
       options:
         - cloudflare-tunnel
+        - eclipse-edc
+        - extractedprism
+        - me-site
+        - obico
+        - spoolman
         - system-upgrade-controller
         - transmission
         - vipalived

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -226,3 +226,30 @@ jobs:
             --field target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  validate-issue-templates:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Chart dropdown in issue templates must list every chart
+        run: |
+          charts=$(for dir in charts/*/; do
+            [ -f "${dir}Chart.yaml" ] && basename "$dir"
+          done | sort)
+
+          rc=0
+          for form in .github/ISSUE_TEMPLATE/bug_report.yml \
+                      .github/ISSUE_TEMPLATE/feature_request.yml \
+                      .github/ISSUE_TEMPLATE/question.yml; do
+            options=$(yq '.body[] | select(.id == "chart") | .attributes.options[]' "$form" | sort)
+            if [ "$charts" != "$options" ]; then
+              echo "::error file=$form::chart dropdown is out of sync with charts/*/"
+              diff <(echo "$charts") <(echo "$options") || true
+              rc=1
+            fi
+          done
+          exit $rc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,7 @@ jobs:
           - charts/extractedprism
           - charts/me-site
           - charts/obico
+          - charts/spoolman
           - charts/system-upgrade-controller
           - charts/transmission
           - charts/vipalived
@@ -67,6 +68,7 @@ jobs:
           - charts/extractedprism
           - charts/me-site
           - charts/obico
+          - charts/spoolman
           - charts/system-upgrade-controller
           - charts/transmission
           - charts/vipalived

--- a/charts/spoolman/.helmignore
+++ b/charts/spoolman/.helmignore
@@ -1,0 +1,39 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+
+# Development and testing
+tests/
+*.test.yaml
+*.md.gotmpl
+
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Artifact Hub metadata (published separately)
+artifacthub-repo.yml

--- a/charts/spoolman/Chart.yaml
+++ b/charts/spoolman/Chart.yaml
@@ -1,0 +1,38 @@
+annotations:
+  artifacthub.io/changes: |-
+    - kind: added
+      description: Initial release of the Spoolman Helm chart
+  artifacthub.io/license: BSD-3-Clause
+  artifacthub.io/links: |
+    - name: Chart Repository
+      url: https://github.com/lexfrei/charts/
+    - name: Spoolman
+      url: https://github.com/Donkie/Spoolman
+  artifacthub.io/signKey: |
+    fingerprint: keyless
+    url: https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master
+apiVersion: v2
+name: spoolman
+description: Spoolman filament spool inventory management for 3D printing, packaged for Kubernetes
+type: application
+version: "0.1.0"
+# renovate: datasource=docker depName=ghcr.io/donkie/spoolman
+appVersion: "0.23.1"
+icon: https://raw.githubusercontent.com/Donkie/Spoolman/master/client/public/pwa-512x512.png
+home: https://github.com/lexfrei/charts/
+keywords:
+  - spoolman
+  - 3d-printing
+  - filament
+  - spool
+  - inventory
+  - helm-chart
+  - kubernetes
+maintainers:
+  - name: lexfrei
+    email: f@lex.la
+    url: https://github.com/lexfrei
+sources:
+  - https://github.com/lexfrei/charts/
+  - https://github.com/Donkie/Spoolman
+kubeVersion: '>=1.19.0-0'

--- a/charts/spoolman/README.md
+++ b/charts/spoolman/README.md
@@ -1,0 +1,211 @@
+# spoolman
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.1](https://img.shields.io/badge/AppVersion-0.23.1-informational?style=flat-square)
+
+## 📊 Status & Metrics
+
+[![Lint and Test](https://github.com/lexfrei/charts/actions/workflows/test.yaml/badge.svg)](https://github.com/lexfrei/charts/actions/workflows/test.yaml)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
+[![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+
+Spoolman filament spool inventory management for 3D printing, packaged for Kubernetes
+
+**Homepage:** <https://github.com/lexfrei/charts/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| lexfrei | <f@lex.la> | <https://github.com/lexfrei> |
+
+## Source Code
+
+* <https://github.com/lexfrei/charts/>
+* <https://github.com/Donkie/Spoolman>
+
+## Requirements
+
+Kubernetes: `>=1.19.0-0`
+
+## Installing the Chart
+
+This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
+
+```bash
+# Install from GHCR
+helm install spoolman \
+  oci://ghcr.io/lexfrei/charts/spoolman \
+  --version 0.1.0
+
+# Install with custom values
+helm install spoolman \
+  oci://ghcr.io/lexfrei/charts/spoolman \
+  --version 0.1.0 \
+  --values values.yaml
+```
+
+### Chart Verification
+
+This chart is signed with [cosign](https://github.com/sigstore/cosign) using keyless signing:
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/spoolman:0.1.0 \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+## Uninstalling the Chart
+
+```bash
+helm delete spoolman
+```
+
+## Security Context Note
+
+The Spoolman image entrypoint starts as `root`, remaps `PUID`/`PGID` and then drops privileges to UID 1000 via `gosu`. Because of this, you must **not** set `securityContext.runAsNonRoot: true` or `securityContext.runAsUser` on the container — doing so prevents the entrypoint from starting. The chart instead sets `fsGroup: 1000` at the pod level so the persistent volume is writable by the application user.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod scheduling |
+| database | object | `{"existingSecret":"","existingSecretKey":"password","host":"","name":"","password":"","port":"","query":"","type":"sqlite","username":""}` | Database configuration. By default Spoolman uses an embedded SQLite database stored on the persistent volume. Set type to postgres, mysql or cockroachdb to use an external database instead. |
+| database.existingSecret | string | `""` | Use an existing Secret for the database password instead of `password` |
+| database.existingSecretKey | string | `"password"` | Key within existingSecret that holds the database password |
+| database.host | string | `""` | Database host (external databases only) |
+| database.name | string | `""` | Database name (external databases only) |
+| database.password | string | `""` | Database password (external databases only). When set and existingSecret is empty, this chart creates a Secret to hold it. An inline password is stored in the Helm release history; prefer existingSecret for production. |
+| database.port | string | `""` | Database port (external databases only) |
+| database.query | string | `""` | Extra connection query parameters (sets SPOOLMAN_DB_QUERY) |
+| database.type | string | `"sqlite"` | Database type: sqlite, postgres, mysql or cockroachdb |
+| database.username | string | `""` | Database username (external databases only) |
+| extraContainers | list | [] | Extra containers to run alongside Spoolman (sidecars) |
+| extraEnv | list | [] | Extra environment variables for the container |
+| extraVolumeMounts | list | [] | Extra volume mounts for the container |
+| extraVolumes | list | [] | Extra volumes to add to the pod (raw Kubernetes volume specs) |
+| fullnameOverride | string | `""` |  |
+| httpRoute | object | `{"annotations":{},"enabled":false,"hostnames":["spoolman.example.com"],"parentRefs":[{"name":"gateway","namespace":"gateway-system"}],"rules":[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]}` | HTTPRoute configuration (Gateway API) |
+| httpRoute.hostnames | list | `["spoolman.example.com"]` | Hostnames for the route |
+| httpRoute.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Parent Gateway references |
+| httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/donkie/spoolman","tag":""}` | Image configuration |
+| image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| imagePullSecrets | list | `[]` |  |
+| ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"spoolman.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["spoolman.example.com"],"secretName":"spoolman-tls"}]}` | Ingress configuration |
+| initContainers | list | [] | Init containers to run before the main container |
+| livenessProbe | object | `{"failureThreshold":6,"initialDelaySeconds":0,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| metrics | object | `{"enabled":false,"serviceMonitor":{"enabled":false,"interval":"30s","labels":{},"path":"/metrics","scrapeTimeout":"10s"}}` | Prometheus metrics configuration |
+| metrics.enabled | bool | `false` | Enable periodic collection of spool/filament Prometheus gauges (sets SPOOLMAN_METRICS_ENABLED). The /metrics endpoint is always served regardless of this flag; disabling it only omits the spool/filament gauges. |
+| metrics.serviceMonitor | object | `{"enabled":false,"interval":"30s","labels":{},"path":"/metrics","scrapeTimeout":"10s"}` | ServiceMonitor for the Prometheus Operator |
+| metrics.serviceMonitor.enabled | bool | `false` | Create a ServiceMonitor. Requires metrics.enabled and the Prometheus Operator CRDs to be installed in the cluster. |
+| metrics.serviceMonitor.interval | string | `"30s"` | Scrape interval |
+| metrics.serviceMonitor.labels | object | `{}` | Extra labels for the ServiceMonitor (e.g. to match a Prometheus selector) |
+| metrics.serviceMonitor.path | string | `"/metrics"` | Metrics path. The chart prepends spoolman.basePath automatically. |
+| metrics.serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout. Must be less than or equal to interval, otherwise the Prometheus Operator rejects the ServiceMonitor. |
+| nameOverride | string | `""` |  |
+| networkPolicy | object | `{"egress":[],"enabled":false,"ingress":[]}` | Network Policy configuration |
+| networkPolicy.egress | list | `[]` | Additional egress rules. Egress to the external database port is added automatically when database.type is not sqlite. |
+| networkPolicy.enabled | bool | `false` | Enable NetworkPolicy |
+| networkPolicy.ingress | list | `[]` | Additional ingress rules. The built-in rule allows the http port from all namespaces, so the default is permissive; tighten access by adding rules here. |
+| nodeSelector | object | `{}` | Node selector for pod scheduling |
+| persistence | object | `{"accessMode":"ReadWriteOnce","enabled":true,"existingClaim":"","mountPath":"/home/app/.local/share/spoolman","size":"1Gi","storageClassName":""}` | Persistence for the SQLite database, backups and logs |
+| persistence.accessMode | string | `"ReadWriteOnce"` | Access mode |
+| persistence.enabled | bool | `true` | Enable persistence (required for the default SQLite database) |
+| persistence.existingClaim | string | `""` | Use an existing PVC instead of creating one |
+| persistence.mountPath | string | `"/home/app/.local/share/spoolman"` | Path inside the container where data is stored. Do not change unless you also override SPOOLMAN_DIR_DATA via extraEnv. |
+| persistence.size | string | `"1Gi"` | Size of the volume |
+| persistence.storageClassName | string | `""` | Storage class name |
+| pgid | int | `1000` | Group ID the application runs as (sets PGID). Also used as the pod fsGroup (unless podSecurityContext.fsGroup is set) so the data volume is writable. |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| podSecurityContext | object | `{"fsGroupChangePolicy":"OnRootMismatch","seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the pod. fsGroup defaults to pgid so the persistent volume is writable by the application group; set fsGroup here to override. |
+| puid | int | `1000` | User ID the application runs as (sets PUID). The image entrypoint starts as root and drops to this UID via gosu. |
+| readinessProbe | object | `{"failureThreshold":3,"initialDelaySeconds":0,"periodSeconds":10,"timeoutSeconds":5}` | Readiness probe configuration |
+| replicaCount | int | `1` | Number of replicas. Spoolman is a singleton; keep at 1 when using the default SQLite database or any ReadWriteOnce volume. |
+| resources | object | `{"limits":{"cpu":"500m","memory":"256Mi"},"requests":{"cpu":"50m","memory":"128Mi"}}` | Resource limits and requests |
+| securityContext | object | `{}` | Security context for the container. WARNING: the Spoolman image entrypoint starts as root and drops privileges to UID 1000 via gosu. Do NOT set runAsNonRoot: true or runAsUser here or the container will fail to start. Left empty by default on purpose. |
+| service | object | `{"annotations":{},"port":80,"type":"ClusterIP"}` | Service configuration |
+| service.annotations | object | `{}` | Service annotations |
+| service.port | int | `80` | Service port (mapped to the container's http port 8000) |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Service account configuration |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use |
+| spoolman | object | `{"automaticBackup":true,"basePath":"","corsOrigin":"","loggingLevel":""}` | Application-level settings, mapped to SPOOLMAN_* environment variables |
+| spoolman.automaticBackup | bool | `true` | Enable nightly automatic SQLite backups (sets SPOOLMAN_AUTOMATIC_BACKUP) |
+| spoolman.basePath | string | `""` | Sub-path to host Spoolman under (sets SPOOLMAN_BASE_PATH), e.g. "/spoolman" |
+| spoolman.corsOrigin | string | `""` | Allowed CORS origin(s), comma-separated or "*" (sets SPOOLMAN_CORS_ORIGIN) |
+| spoolman.loggingLevel | string | `""` | Logging level: DEBUG, INFO, WARNING, ERROR or CRITICAL (sets SPOOLMAN_LOGGING_LEVEL) |
+| startupProbe | object | `{"failureThreshold":30,"initialDelaySeconds":5,"periodSeconds":5,"timeoutSeconds":3}` | Startup probe. Generous failureThreshold to allow database migrations on first start. |
+| timezone | string | `"UTC"` | Container timezone, set via the TZ environment variable. Honored by the glibc base image for log timestamps; Spoolman itself does not read TZ. |
+| tolerations | list | `[]` | Tolerations for pod scheduling |
+| updateStrategy | object | `{"type":"Recreate"}` | Update strategy. Recreate avoids two pods mounting the same ReadWriteOnce volume during a rollout. With a ReadWriteMany volume and replicaCount > 1, switch to RollingUpdate to avoid downtime on every rollout. |
+
+## Example Configurations
+
+### Basic deployment with Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: spoolman.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: spoolman-tls
+      hosts:
+        - spoolman.example.com
+```
+
+### Using Gateway API (HTTPRoute)
+
+```yaml
+httpRoute:
+  enabled: true
+  hostnames:
+    - spoolman.example.com
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+```
+
+### External PostgreSQL database
+
+```yaml
+database:
+  type: postgres
+  host: postgres.databases.svc.cluster.local
+  port: 5432
+  name: spoolman
+  username: spoolman
+  # Reference the DB password from an existing Secret (recommended):
+  existingSecret: spoolman-db
+  existingSecretKey: password
+  # ...or set it inline and the chart creates the Secret for you:
+  # password: "change-me"
+
+# SQLite persistence is not needed with an external database
+persistence:
+  enabled: false
+```
+
+### Prometheus metrics with a ServiceMonitor
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    labels:
+      release: kube-prometheus-stack
+```
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/spoolman/README.md.gotmpl
+++ b/charts/spoolman/README.md.gotmpl
@@ -1,0 +1,127 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+## 📊 Status & Metrics
+
+[![Lint and Test](https://github.com/lexfrei/charts/actions/workflows/test.yaml/badge.svg)](https://github.com/lexfrei/charts/actions/workflows/test.yaml)
+[![License](https://img.shields.io/badge/License-BSD--3--Clause-blue.svg)](https://github.com/lexfrei/charts/blob/master/LICENSE)
+[![Helm Version](https://img.shields.io/badge/Helm-v3-informational?logo=helm)](https://helm.sh/)
+[![Kubernetes Version](https://img.shields.io/badge/Kubernetes-1.19%2B-blue?logo=kubernetes)](https://kubernetes.io/)
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Installing the Chart
+
+This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
+
+```bash
+# Install from GHCR
+helm install spoolman \
+  oci://ghcr.io/lexfrei/charts/spoolman \
+  --version {{ template "chart.version" . }}
+
+# Install with custom values
+helm install spoolman \
+  oci://ghcr.io/lexfrei/charts/spoolman \
+  --version {{ template "chart.version" . }} \
+  --values values.yaml
+```
+
+### Chart Verification
+
+This chart is signed with [cosign](https://github.com/sigstore/cosign) using keyless signing:
+
+```bash
+cosign verify \
+  ghcr.io/lexfrei/charts/spoolman:{{ template "chart.version" . }} \
+  --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+## Uninstalling the Chart
+
+```bash
+helm delete spoolman
+```
+
+## Security Context Note
+
+The Spoolman image entrypoint starts as `root`, remaps `PUID`/`PGID` and then drops privileges to UID 1000 via `gosu`. Because of this, you must **not** set `securityContext.runAsNonRoot: true` or `securityContext.runAsUser` on the container — doing so prevents the entrypoint from starting. The chart instead sets `fsGroup: 1000` at the pod level so the persistent volume is writable by the application user.
+
+{{ template "chart.valuesSection" . }}
+
+## Example Configurations
+
+### Basic deployment with Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: spoolman.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: spoolman-tls
+      hosts:
+        - spoolman.example.com
+```
+
+### Using Gateway API (HTTPRoute)
+
+```yaml
+httpRoute:
+  enabled: true
+  hostnames:
+    - spoolman.example.com
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+```
+
+### External PostgreSQL database
+
+```yaml
+database:
+  type: postgres
+  host: postgres.databases.svc.cluster.local
+  port: 5432
+  name: spoolman
+  username: spoolman
+  # Reference the DB password from an existing Secret (recommended):
+  existingSecret: spoolman-db
+  existingSecretKey: password
+  # ...or set it inline and the chart creates the Secret for you:
+  # password: "change-me"
+
+# SQLite persistence is not needed with an external database
+persistence:
+  enabled: false
+```
+
+### Prometheus metrics with a ServiceMonitor
+
+```yaml
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    labels:
+      release: kube-prometheus-stack
+```
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/spoolman/artifacthub-repo.yml
+++ b/charts/spoolman/artifacthub-repo.yml
@@ -1,0 +1,6 @@
+# Artifact Hub repository metadata
+# See: https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-support
+repositoryID: 15118924-7d07-4187-8440-e0905aefbf0e
+owners:
+  - name: Aleksei Sviridkin
+    email: f@lex.la

--- a/charts/spoolman/templates/NOTES.txt
+++ b/charts/spoolman/templates/NOTES.txt
@@ -1,0 +1,42 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Spoolman filament inventory manager has been deployed.
+
+Release Name: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+To check the status of your deployment:
+
+  kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/name={{ include "spoolman.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+{{- if .Values.ingress.enabled }}
+
+Spoolman is accessible at:
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  - http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else }}
+
+To access Spoolman, forward the service port:
+
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "spoolman.fullname" . }} 8000:{{ .Values.service.port }}
+
+Then open: http://localhost:8000{{ include "spoolman.basePath" . }}
+{{- end }}
+
+Database:
+{{- if eq .Values.database.type "sqlite" }}
+  SQLite (embedded){{ if .Values.persistence.enabled }}, persisted on a {{ .Values.persistence.size }} volume{{ else }} — WARNING: persistence is disabled, data will be lost on pod restart{{ end }}
+{{- else }}
+  {{ .Values.database.type }} at {{ .Values.database.host }}{{ if .Values.database.port }}:{{ .Values.database.port }}{{ end }}
+{{- end }}
+
+To view logs:
+
+  kubectl --namespace {{ .Release.Namespace }} logs -l "app.kubernetes.io/name={{ include "spoolman.name" . }}" --tail=100 --follow
+
+For more information:
+  - Chart: https://github.com/lexfrei/charts/tree/master/charts/spoolman
+  - Spoolman: https://github.com/Donkie/Spoolman

--- a/charts/spoolman/templates/_helpers.tpl
+++ b/charts/spoolman/templates/_helpers.tpl
@@ -1,0 +1,57 @@
+{{- define "spoolman.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "spoolman.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "spoolman.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "spoolman.labels" -}}
+helm.sh/chart: {{ include "spoolman.chart" . }}
+{{ include "spoolman.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "spoolman.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spoolman.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "spoolman.basePath" -}}
+{{- with .Values.spoolman.basePath | trimAll "/" }}
+{{- printf "/%s" . }}
+{{- end }}
+{{- end }}
+
+{{- define "spoolman.dbPort" -}}
+{{- if .Values.database.port }}
+{{- .Values.database.port }}
+{{- else if eq .Values.database.type "postgres" }}5432
+{{- else if eq .Values.database.type "mysql" }}3306
+{{- else if eq .Values.database.type "cockroachdb" }}26257
+{{- end }}
+{{- end }}
+
+{{- define "spoolman.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "spoolman.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/spoolman/templates/deployment.yaml
+++ b/charts/spoolman/templates/deployment.yaml
@@ -1,0 +1,189 @@
+{{- if and (gt (int .Values.replicaCount) 1) .Values.persistence.enabled (eq .Values.persistence.accessMode "ReadWriteOnce") }}
+{{- fail "replicaCount > 1 is not supported with a ReadWriteOnce persistence volume; use a ReadWriteMany access mode, or an external database with persistence.enabled=false" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spoolman.fullname" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "spoolman.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "spoolman.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "spoolman.serviceAccountName" . }}
+      securityContext:
+        {{- if not (hasKey .Values.podSecurityContext "fsGroup") }}
+        fsGroup: {{ .Values.pgid }}
+        {{- end }}
+        {{- with .Values.podSecurityContext }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: TZ
+              value: {{ .Values.timezone | quote }}
+            - name: PUID
+              value: {{ .Values.puid | quote }}
+            - name: PGID
+              value: {{ .Values.pgid | quote }}
+            # Pin the listen port to the container port. The entrypoint defaults
+            # to 8000 and the image EXPOSEs 8000, but the shipped .env.example
+            # sets SPOOLMAN_PORT=7912, so pin it explicitly.
+            - name: SPOOLMAN_PORT
+              value: "8000"
+            # Bind to all interfaces. The entrypoint already defaults this to
+            # 0.0.0.0; pinned for parity with SPOOLMAN_PORT and independence from
+            # a mounted .env.
+            - name: SPOOLMAN_HOST
+              value: "0.0.0.0"
+            - name: SPOOLMAN_AUTOMATIC_BACKUP
+              value: {{ ternary "TRUE" "FALSE" .Values.spoolman.automaticBackup | quote }}
+            {{- with (include "spoolman.basePath" .) }}
+            - name: SPOOLMAN_BASE_PATH
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if .Values.spoolman.corsOrigin }}
+            - name: SPOOLMAN_CORS_ORIGIN
+              value: {{ .Values.spoolman.corsOrigin | quote }}
+            {{- end }}
+            {{- if .Values.spoolman.loggingLevel }}
+            - name: SPOOLMAN_LOGGING_LEVEL
+              value: {{ .Values.spoolman.loggingLevel | quote }}
+            {{- end }}
+            {{- if .Values.metrics.enabled }}
+            - name: SPOOLMAN_METRICS_ENABLED
+              value: "TRUE"
+            {{- end }}
+            {{- if ne .Values.database.type "sqlite" }}
+            - name: SPOOLMAN_DB_TYPE
+              value: {{ .Values.database.type | quote }}
+            {{- if .Values.database.host }}
+            - name: SPOOLMAN_DB_HOST
+              value: {{ .Values.database.host | quote }}
+            {{- end }}
+            {{- if .Values.database.port }}
+            - name: SPOOLMAN_DB_PORT
+              value: {{ printf "%v" .Values.database.port | quote }}
+            {{- end }}
+            {{- if .Values.database.name }}
+            - name: SPOOLMAN_DB_NAME
+              value: {{ .Values.database.name | quote }}
+            {{- end }}
+            {{- if .Values.database.username }}
+            - name: SPOOLMAN_DB_USERNAME
+              value: {{ .Values.database.username | quote }}
+            {{- end }}
+            {{- if .Values.database.query }}
+            - name: SPOOLMAN_DB_QUERY
+              value: {{ .Values.database.query | quote }}
+            {{- end }}
+            {{- if .Values.database.existingSecret }}
+            - name: SPOOLMAN_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.existingSecret }}
+                  key: {{ .Values.database.existingSecretKey }}
+            {{- else if .Values.database.password }}
+            - name: SPOOLMAN_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "spoolman.fullname" . }}
+                  key: password
+            {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: {{ include "spoolman.basePath" . }}/api/v1/health
+              port: http
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ include "spoolman.basePath" . }}/api/v1/health
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ include "spoolman.basePath" . }}/api/v1/health
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          volumeMounts:
+            {{- if .Values.persistence.enabled }}
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.persistence.enabled .Values.extraVolumes }}
+      volumes:
+        {{- if .Values.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (include "spoolman.fullname" .) }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/spoolman/templates/httproute.yaml
+++ b/charts/spoolman/templates/httproute.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "spoolman.fullname" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.httpRoute.rules }}
+    - matches:
+        {{- toYaml .matches | nindent 8 }}
+      {{- with .filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      backendRefs:
+        - name: {{ include "spoolman.fullname" $ }}
+          port: {{ $.Values.service.port }}
+          {{- with .weight }}
+          weight: {{ . }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/spoolman/templates/ingress.yaml
+++ b/charts/spoolman/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "spoolman.fullname" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "spoolman.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/spoolman/templates/networkpolicy.yaml
+++ b/charts/spoolman/templates/networkpolicy.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "spoolman.fullname" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "spoolman.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow web UI / API access from any namespace (scope via networkPolicy.ingress)
+    - from:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: http
+    {{- with .Values.networkPolicy.ingress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- if ne .Values.database.type "sqlite" }}
+    # Allow the database port to any in-cluster pod (broad: not scoped to the DB
+    # pod). Add a networkPolicy.egress ipBlock rule for a database outside the
+    # cluster, or tighten this with podSelector via networkPolicy.egress.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: TCP
+          port: {{ include "spoolman.dbPort" . | int }}
+    {{- end }}
+    {{- with .Values.networkPolicy.egress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/spoolman/templates/pvc.yaml
+++ b/charts/spoolman/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "spoolman.fullname" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/spoolman/templates/secret.yaml
+++ b/charts/spoolman/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and (ne .Values.database.type "sqlite") (not .Values.database.existingSecret) .Values.database.password }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "spoolman.fullname" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password: {{ .Values.database.password | b64enc | quote }}
+{{- end }}

--- a/charts/spoolman/templates/service.yaml
+++ b/charts/spoolman/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spoolman.fullname" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "spoolman.selectorLabels" . | nindent 4 }}

--- a/charts/spoolman/templates/serviceaccount.yaml
+++ b/charts/spoolman/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spoolman.serviceAccountName" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/spoolman/templates/servicemonitor.yaml
+++ b/charts/spoolman/templates/servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "spoolman.fullname" . }}
+  labels:
+    {{- include "spoolman.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "spoolman.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: {{ include "spoolman.basePath" . }}{{ .Values.metrics.serviceMonitor.path }}
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/spoolman/tests/database_test.yaml
+++ b/charts/spoolman/tests/database_test.yaml
@@ -1,0 +1,93 @@
+suite: test database
+templates:
+  - deployment.yaml
+  - secret.yaml
+tests:
+  - it: should not create a Secret with the default SQLite database
+    template: secret.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should set database env vars for an external database
+    template: deployment.yaml
+    set:
+      database.type: postgres
+      database.host: db.example.com
+      database.port: 5432
+      database.name: spoolman
+      database.username: spooluser
+      database.query: "sslmode=require"
+      database.password: s3cret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_DB_TYPE
+            value: postgres
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_DB_HOST
+            value: db.example.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_DB_PORT
+            value: "5432"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_DB_NAME
+            value: spoolman
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_DB_USERNAME
+            value: spooluser
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_DB_QUERY
+            value: "sslmode=require"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: RELEASE-NAME-spoolman
+                key: password
+
+  - it: should create a Secret for an inline database password
+    template: secret.yaml
+    set:
+      database.type: postgres
+      database.password: s3cret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: data.password
+          value: czNjcmV0
+
+  - it: should reference an existing secret without creating one
+    set:
+      database.type: mysql
+      database.existingSecret: my-db-secret
+      database.existingSecretKey: db-pass
+    asserts:
+      - template: secret.yaml
+        hasDocuments:
+          count: 0
+      - template: deployment.yaml
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_DB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-db-secret
+                key: db-pass

--- a/charts/spoolman/tests/deployment_test.yaml
+++ b/charts/spoolman/tests/deployment_test.yaml
@@ -1,0 +1,288 @@
+suite: test deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: should create a Deployment with default values
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: apiVersion
+          value: apps/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spoolman
+
+  - it: should use the appVersion as the default image tag
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/donkie/spoolman:0.23.1"
+
+  - it: should allow overriding the image tag
+    set:
+      image.tag: "0.99.0"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/donkie/spoolman:0.99.0"
+
+  - it: should use the Recreate strategy
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should expose the http port on 8000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8000
+
+  - it: should set fsGroup on the pod and not force a non-root container
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 1000
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.runAsNonRoot
+
+  - it: should default fsGroup to pgid
+    set:
+      pgid: 2000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+
+  - it: should let podSecurityContext.fsGroup override pgid
+    set:
+      pgid: 2000
+      podSecurityContext:
+        fsGroup: 3000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 3000
+
+  - it: should set SPOOLMAN_METRICS_ENABLED only when metrics are enabled
+    set:
+      metrics.enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_METRICS_ENABLED
+            value: "TRUE"
+
+  - it: should set base environment variables
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TZ
+            value: "UTC"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: PUID
+            value: "1000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_AUTOMATIC_BACKUP
+            value: "TRUE"
+
+  - it: should pin the listen host and port to match the container port
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_PORT
+            value: "8000"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_HOST
+            value: "0.0.0.0"
+
+  - it: should not set database env vars with the default SQLite database
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].env
+          count: 6
+
+  - it: should emit application env vars when configured
+    set:
+      spoolman.corsOrigin: "https://ui.example.com"
+      spoolman.loggingLevel: DEBUG
+      spoolman.automaticBackup: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_CORS_ORIGIN
+            value: "https://ui.example.com"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_LOGGING_LEVEL
+            value: DEBUG
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_AUTOMATIC_BACKUP
+            value: "FALSE"
+
+  - it: should inject extra env, volumes, mounts and containers
+    set:
+      extraEnv:
+        - name: EXTRA_FLAG
+          value: "1"
+      extraVolumes:
+        - name: extra
+          emptyDir: {}
+      extraVolumeMounts:
+        - name: extra
+          mountPath: /extra
+      initContainers:
+        - name: init-extra
+          image: busybox:latest
+      extraContainers:
+        - name: sidecar
+          image: busybox:latest
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_FLAG
+            value: "1"
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: extra
+            mountPath: /extra
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: extra
+            emptyDir: {}
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-extra
+      - lengthEqual:
+          path: spec.template.spec.containers
+          count: 2
+
+  - it: should probe the health endpoint
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /api/v1/health
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /api/v1/health
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /api/v1/health
+
+  - it: should prefix the probe path with basePath when set
+    set:
+      spoolman.basePath: /spoolman
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /spoolman/api/v1/health
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_BASE_PATH
+            value: /spoolman
+
+  - it: should strip a trailing slash from basePath
+    set:
+      spoolman.basePath: /spoolman/
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /spoolman/api/v1/health
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_BASE_PATH
+            value: /spoolman
+
+  - it: should add a leading slash to a basePath given without one
+    set:
+      spoolman.basePath: spoolman
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /spoolman/api/v1/health
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SPOOLMAN_BASE_PATH
+            value: /spoolman
+
+  - it: should mount the data volume by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: data
+            mountPath: /home/app/.local/share/spoolman
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: RELEASE-NAME-spoolman
+
+  - it: should reference an existing claim when set
+    set:
+      persistence.existingClaim: my-claim
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            persistentVolumeClaim:
+              claimName: my-claim
+
+  - it: should not mount a data volume when persistence is disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+
+  - it: should reject replicaCount > 1 with a ReadWriteOnce volume
+    set:
+      replicaCount: 2
+    asserts:
+      - failedTemplate:
+          errorMessage: "replicaCount > 1 is not supported with a ReadWriteOnce persistence volume; use a ReadWriteMany access mode, or an external database with persistence.enabled=false"
+
+  - it: should allow replicaCount > 1 with a ReadWriteMany volume
+    set:
+      replicaCount: 2
+      persistence.accessMode: ReadWriteMany
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+
+  - it: should allow replicaCount > 1 when persistence is disabled
+    set:
+      replicaCount: 2
+      persistence.enabled: false
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2

--- a/charts/spoolman/tests/httproute_test.yaml
+++ b/charts/spoolman/tests/httproute_test.yaml
@@ -1,0 +1,31 @@
+suite: test httproute
+templates:
+  - httproute.yaml
+tests:
+  - it: should not render an HTTPRoute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an HTTPRoute when enabled
+    set:
+      httpRoute.enabled: true
+      httpRoute.hostnames:
+        - spoolman.example.com
+      httpRoute.parentRefs:
+        - name: gateway
+          namespace: gateway-system
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.hostnames[0]
+          value: spoolman.example.com
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-spoolman
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 80

--- a/charts/spoolman/tests/ingress_test.yaml
+++ b/charts/spoolman/tests/ingress_test.yaml
@@ -1,0 +1,35 @@
+suite: test ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: should not render an Ingress by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render an Ingress when enabled
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+      ingress.hosts:
+        - host: spoolman.example.com
+          paths:
+            - path: /
+              pathType: Prefix
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+      - equal:
+          path: spec.rules[0].host
+          value: spoolman.example.com
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: RELEASE-NAME-spoolman
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: http

--- a/charts/spoolman/tests/networkpolicy_test.yaml
+++ b/charts/spoolman/tests/networkpolicy_test.yaml
@@ -1,0 +1,92 @@
+suite: test networkpolicy
+templates:
+  - networkpolicy.yaml
+tests:
+  - it: should not render a NetworkPolicy by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a NetworkPolicy when enabled
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - contains:
+          path: spec.policyTypes
+          content: Egress
+      - equal:
+          path: spec.ingress[0].ports[0].port
+          value: http
+
+  - it: should append extra egress rules
+    set:
+      networkPolicy.enabled: true
+      networkPolicy.egress:
+        - to:
+            - ipBlock:
+                cidr: 198.51.100.0/24
+          ports:
+            - protocol: TCP
+              port: 5432
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 2
+
+  - it: should not open database egress with the default SQLite database
+    set:
+      networkPolicy.enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 1
+
+  - it: should open egress to an explicit external database port
+    set:
+      networkPolicy.enabled: true
+      database.type: postgres
+      database.port: 6432
+    asserts:
+      - lengthEqual:
+          path: spec.egress
+          count: 2
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 6432
+
+  - it: should default the database egress port from the database type
+    set:
+      networkPolicy.enabled: true
+      database.type: mysql
+    asserts:
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 3306
+
+  - it: should allow database egress to any in-cluster pod on the DB port
+    set:
+      networkPolicy.enabled: true
+      database.type: postgres
+    asserts:
+      - isNotEmpty:
+          path: spec.egress[1].to
+      - equal:
+          path: spec.egress[1].to[0].namespaceSelector
+          value: {}
+
+  - it: should handle a database port given as a string
+    set:
+      networkPolicy.enabled: true
+      database.type: postgres
+      database.port: "6432"
+    asserts:
+      - equal:
+          path: spec.egress[1].ports[0].port
+          value: 6432

--- a/charts/spoolman/tests/persistence_test.yaml
+++ b/charts/spoolman/tests/persistence_test.yaml
@@ -1,0 +1,49 @@
+suite: test persistence
+templates:
+  - pvc.yaml
+tests:
+  - it: should create a PVC by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PersistentVolumeClaim
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-spoolman
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteOnce
+      - equal:
+          path: spec.resources.requests.storage
+          value: 1Gi
+
+  - it: should honor size and access mode overrides
+    set:
+      persistence.size: 5Gi
+      persistence.accessMode: ReadWriteMany
+      persistence.storageClassName: fast
+    asserts:
+      - equal:
+          path: spec.resources.requests.storage
+          value: 5Gi
+      - contains:
+          path: spec.accessModes
+          content: ReadWriteMany
+      - equal:
+          path: spec.storageClassName
+          value: fast
+
+  - it: should not create a PVC when using an existing claim
+    set:
+      persistence.existingClaim: my-claim
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not create a PVC when persistence is disabled
+    set:
+      persistence.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/spoolman/tests/service_test.yaml
+++ b/charts/spoolman/tests/service_test.yaml
@@ -1,0 +1,39 @@
+suite: test service
+templates:
+  - service.yaml
+tests:
+  - it: should create a ClusterIP service on port 80 targeting http
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.type
+          value: ClusterIP
+      - equal:
+          path: spec.ports[0].port
+          value: 80
+      - equal:
+          path: spec.ports[0].targetPort
+          value: http
+      - equal:
+          path: spec.ports[0].name
+          value: http
+
+  - it: should honor service overrides
+    set:
+      service.type: LoadBalancer
+      service.port: 8000
+      service.annotations:
+        foo: bar
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.ports[0].port
+          value: 8000
+      - equal:
+          path: metadata.annotations.foo
+          value: bar

--- a/charts/spoolman/tests/servicemonitor_test.yaml
+++ b/charts/spoolman/tests/servicemonitor_test.yaml
@@ -1,0 +1,72 @@
+suite: test servicemonitor
+templates:
+  - servicemonitor.yaml
+tests:
+  - it: should not render a ServiceMonitor by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render a ServiceMonitor when metrics are enabled but the monitor is not
+    set:
+      metrics.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ServiceMonitor when both metrics and the monitor are enabled
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.endpoints[0].port
+          value: http
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics
+      - equal:
+          path: spec.endpoints[0].interval
+          value: 30s
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 10s
+
+  - it: should pass through serviceMonitor labels and scrapeTimeout overrides
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.scrapeTimeout: 15s
+      metrics.serviceMonitor.labels:
+        release: kube-prometheus-stack
+    asserts:
+      - equal:
+          path: spec.endpoints[0].scrapeTimeout
+          value: 15s
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+
+  - it: should prepend basePath to the metrics path
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+      spoolman.basePath: /spoolman
+    asserts:
+      - equal:
+          path: spec.endpoints[0].path
+          value: /spoolman/metrics
+
+  - it: should strip a trailing slash from basePath in the metrics path
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+      spoolman.basePath: /spoolman/
+    asserts:
+      - equal:
+          path: spec.endpoints[0].path
+          value: /spoolman/metrics

--- a/charts/spoolman/values.schema.json
+++ b/charts/spoolman/values.schema.json
@@ -1,0 +1,618 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Spoolman Values",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Image repository"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"],
+          "description": "Image pull policy"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Overrides the image tag whose default is the chart appVersion"
+        }
+      },
+      "required": ["repository", "pullPolicy"]
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Image pull secrets"
+    },
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the name of the chart"
+    },
+    "fullnameOverride": {
+      "type": "string",
+      "description": "Override the fullname of the chart"
+    },
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of replicas (keep at 1 with SQLite or ReadWriteOnce storage)"
+    },
+    "timezone": {
+      "type": "string",
+      "description": "Timezone for the container (sets TZ)"
+    },
+    "puid": {
+      "type": "integer",
+      "description": "User ID the application runs as (sets PUID)"
+    },
+    "pgid": {
+      "type": "integer",
+      "description": "Group ID the application runs as (sets PGID)"
+    },
+    "spoolman": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "basePath": {
+          "type": "string",
+          "description": "Sub-path to host Spoolman under (sets SPOOLMAN_BASE_PATH)"
+        },
+        "corsOrigin": {
+          "type": "string",
+          "description": "Allowed CORS origin(s) (sets SPOOLMAN_CORS_ORIGIN)"
+        },
+        "loggingLevel": {
+          "type": "string",
+          "enum": ["", "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+          "description": "Logging level (sets SPOOLMAN_LOGGING_LEVEL)"
+        },
+        "automaticBackup": {
+          "type": "boolean",
+          "description": "Enable nightly automatic SQLite backups (sets SPOOLMAN_AUTOMATIC_BACKUP)"
+        }
+      }
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["sqlite", "postgres", "mysql", "cockroachdb"],
+          "description": "Database type"
+        },
+        "host": {
+          "type": "string",
+          "description": "Database host (external databases only)"
+        },
+        "port": {
+          "description": "Database port (external databases only)",
+          "anyOf": [
+            {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 65535
+            },
+            {
+              "type": "string",
+              "pattern": "^([1-9][0-9]{0,4})?$"
+            }
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Database name (external databases only)"
+        },
+        "username": {
+          "type": "string",
+          "description": "Database username (external databases only)"
+        },
+        "query": {
+          "type": "string",
+          "description": "Extra connection query parameters (sets SPOOLMAN_DB_QUERY)"
+        },
+        "password": {
+          "type": "string",
+          "description": "Database password (external databases only)"
+        },
+        "existingSecret": {
+          "type": "string",
+          "description": "Use an existing Secret for the database password"
+        },
+        "existingSecretKey": {
+          "type": "string",
+          "description": "Key within existingSecret that holds the database password"
+        }
+      },
+      "required": ["type"]
+    },
+    "persistence": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable persistence (required for the default SQLite database)"
+        },
+        "mountPath": {
+          "type": "string",
+          "description": "Path inside the container where data is stored"
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "Storage class name"
+        },
+        "accessMode": {
+          "type": "string",
+          "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany"],
+          "description": "Access mode"
+        },
+        "size": {
+          "type": "string",
+          "pattern": "^[0-9]+(Mi|Gi|Ti|M|G|T)$",
+          "description": "Size of the volume"
+        },
+        "existingClaim": {
+          "type": "string",
+          "description": "Use an existing PVC instead of creating one"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "service": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"],
+          "description": "Service type"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Service port"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Service annotations (must be string key-value pairs)"
+        }
+      },
+      "required": ["type", "port"]
+    },
+    "ingress": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable ingress"
+        },
+        "className": {
+          "type": "string",
+          "description": "Ingress class name"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Ingress annotations (must be string key-value pairs)"
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": {
+                "type": "string",
+                "description": "Hostname"
+              },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "pathType": {
+                      "type": "string",
+                      "enum": ["Prefix", "Exact", "ImplementationSpecific"]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "secretName": {
+                "type": "string"
+              },
+              "hosts": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "required": ["enabled"]
+    },
+    "httpRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable HTTPRoute (Gateway API)"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "HTTPRoute annotations (must be string key-value pairs)"
+        },
+        "parentRefs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Gateway name"
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Gateway namespace"
+              },
+              "sectionName": {
+                "type": "string",
+                "description": "Optional: specific listener on the Gateway"
+              }
+            }
+          },
+          "description": "Parent Gateway references"
+        },
+        "hostnames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Hostnames for the route"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "matches": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "filters": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              },
+              "weight": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 1000000
+              }
+            }
+          },
+          "description": "Routing rules"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable periodic collection of spool/filament Prometheus gauges (sets SPOOLMAN_METRICS_ENABLED); the /metrics endpoint is always served regardless"
+        },
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Create a ServiceMonitor (requires the Prometheus Operator CRDs)"
+            },
+            "interval": {
+              "type": "string",
+              "description": "Scrape interval"
+            },
+            "scrapeTimeout": {
+              "type": "string",
+              "description": "Scrape timeout"
+            },
+            "path": {
+              "type": "string",
+              "description": "Metrics path"
+            },
+            "labels": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Extra labels for the ServiceMonitor (must be string key-value pairs)"
+            }
+          },
+          "required": ["enabled"]
+        }
+      },
+      "required": ["enabled"]
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "description": "Memory request"
+            },
+            "cpu": {
+              "type": "string",
+              "description": "CPU request"
+            }
+          }
+        },
+        "limits": {
+          "type": "object",
+          "properties": {
+            "memory": {
+              "type": "string",
+              "description": "Memory limit"
+            },
+            "cpu": {
+              "type": "string",
+              "description": "CPU limit"
+            }
+          }
+        }
+      }
+    },
+    "podSecurityContext": {
+      "type": "object",
+      "description": "Security context for the pod"
+    },
+    "securityContext": {
+      "type": "object",
+      "description": "Security context for the container"
+    },
+    "startupProbe": {
+      "type": "object",
+      "description": "Startup probe configuration",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "livenessProbe": {
+      "type": "object",
+      "description": "Liveness probe configuration",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "readinessProbe": {
+      "type": "object",
+      "description": "Readiness probe configuration",
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "type": "boolean",
+          "description": "Specifies whether a service account should be created"
+        },
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Annotations to add to the service account (must be string key-value pairs)"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the service account to use"
+        }
+      },
+      "required": ["create"]
+    },
+    "updateStrategy": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["RollingUpdate", "Recreate"],
+          "description": "Update strategy type"
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable NetworkPolicy"
+        },
+        "ingress": {
+          "type": "array",
+          "description": "Additional ingress rules"
+        },
+        "egress": {
+          "type": "array",
+          "description": "Additional egress rules"
+        }
+      },
+      "required": ["enabled"]
+    },
+    "nodeSelector": {
+      "type": "object",
+      "description": "Node selector"
+    },
+    "tolerations": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Tolerations"
+    },
+    "affinity": {
+      "type": "object",
+      "description": "Affinity rules"
+    },
+    "podAnnotations": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Pod annotations (must be string key-value pairs)"
+    },
+    "podLabels": {
+      "type": "object",
+      "description": "Pod labels"
+    },
+    "extraEnv": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Extra environment variables for the container"
+    },
+    "initContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Init containers to run before the main container"
+    },
+    "extraContainers": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Extra containers to run alongside Spoolman (sidecars)"
+    },
+    "extraVolumes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Volume name"
+          }
+        },
+        "required": ["name"]
+      },
+      "description": "Extra volumes to add to the pod (raw Kubernetes volume specs)"
+    },
+    "extraVolumeMounts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Volume name to mount"
+          },
+          "mountPath": {
+            "type": "string",
+            "description": "Path to mount the volume"
+          },
+          "subPath": {
+            "type": "string",
+            "description": "SubPath within the volume"
+          },
+          "readOnly": {
+            "type": "boolean",
+            "description": "Mount as read-only"
+          }
+        },
+        "required": ["name", "mountPath"]
+      },
+      "description": "Extra volume mounts for the container"
+    }
+  },
+  "required": ["image", "service", "persistence", "database"]
+}

--- a/charts/spoolman/values.yaml
+++ b/charts/spoolman/values.yaml
@@ -1,0 +1,250 @@
+# Default values for spoolman
+
+# -- Image configuration
+image:
+  repository: ghcr.io/donkie/spoolman
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# -- Number of replicas. Spoolman is a singleton; keep at 1 when using the
+# default SQLite database or any ReadWriteOnce volume.
+replicaCount: 1
+
+# -- Container timezone, set via the TZ environment variable. Honored by the
+# glibc base image for log timestamps; Spoolman itself does not read TZ.
+timezone: "UTC"
+
+# -- User ID the application runs as (sets PUID). The image entrypoint starts as
+# root and drops to this UID via gosu.
+puid: 1000
+# -- Group ID the application runs as (sets PGID). Also used as the pod fsGroup
+# (unless podSecurityContext.fsGroup is set) so the data volume is writable.
+pgid: 1000
+
+# -- Application-level settings, mapped to SPOOLMAN_* environment variables
+spoolman:
+  # -- Sub-path to host Spoolman under (sets SPOOLMAN_BASE_PATH), e.g. "/spoolman"
+  basePath: ""
+  # -- Allowed CORS origin(s), comma-separated or "*" (sets SPOOLMAN_CORS_ORIGIN)
+  corsOrigin: ""
+  # -- Logging level: DEBUG, INFO, WARNING, ERROR or CRITICAL (sets SPOOLMAN_LOGGING_LEVEL)
+  loggingLevel: ""
+  # -- Enable nightly automatic SQLite backups (sets SPOOLMAN_AUTOMATIC_BACKUP)
+  automaticBackup: true
+
+# -- Database configuration. By default Spoolman uses an embedded SQLite database
+# stored on the persistent volume. Set type to postgres, mysql or cockroachdb to
+# use an external database instead.
+database:
+  # -- Database type: sqlite, postgres, mysql or cockroachdb
+  type: sqlite
+  # -- Database host (external databases only)
+  host: ""
+  # -- Database port (external databases only)
+  port: ""
+  # -- Database name (external databases only)
+  name: ""
+  # -- Database username (external databases only)
+  username: ""
+  # -- Extra connection query parameters (sets SPOOLMAN_DB_QUERY)
+  query: ""
+  # -- Database password (external databases only). When set and existingSecret
+  # is empty, this chart creates a Secret to hold it. An inline password is
+  # stored in the Helm release history; prefer existingSecret for production.
+  password: ""
+  # -- Use an existing Secret for the database password instead of `password`
+  existingSecret: ""
+  # -- Key within existingSecret that holds the database password
+  existingSecretKey: "password"
+
+# -- Persistence for the SQLite database, backups and logs
+persistence:
+  # -- Enable persistence (required for the default SQLite database)
+  enabled: true
+  # -- Path inside the container where data is stored. Do not change unless you
+  # also override SPOOLMAN_DIR_DATA via extraEnv.
+  mountPath: /home/app/.local/share/spoolman
+  # -- Storage class name
+  storageClassName: ""
+  # -- Access mode
+  accessMode: ReadWriteOnce
+  # -- Size of the volume
+  size: 1Gi
+  # -- Use an existing PVC instead of creating one
+  existingClaim: ""
+
+# -- Service configuration
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port (mapped to the container's http port 8000)
+  port: 80
+  # -- Service annotations
+  annotations: {}
+
+# -- Ingress configuration
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: spoolman.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: spoolman-tls
+      hosts:
+        - spoolman.example.com
+
+# -- HTTPRoute configuration (Gateway API)
+httpRoute:
+  enabled: false
+  annotations: {}
+  # -- Parent Gateway references
+  parentRefs:
+    - name: gateway
+      namespace: gateway-system
+      # sectionName: https-listener  # Optional: specific listener on the Gateway
+  # -- Hostnames for the route
+  hostnames:
+    - spoolman.example.com
+  # -- Routing rules
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+
+# -- Prometheus metrics configuration
+metrics:
+  # -- Enable periodic collection of spool/filament Prometheus gauges (sets
+  # SPOOLMAN_METRICS_ENABLED). The /metrics endpoint is always served regardless
+  # of this flag; disabling it only omits the spool/filament gauges.
+  enabled: false
+  # -- ServiceMonitor for the Prometheus Operator
+  serviceMonitor:
+    # -- Create a ServiceMonitor. Requires metrics.enabled and the Prometheus
+    # Operator CRDs to be installed in the cluster.
+    enabled: false
+    # -- Scrape interval
+    interval: 30s
+    # -- Scrape timeout. Must be less than or equal to interval, otherwise the
+    # Prometheus Operator rejects the ServiceMonitor.
+    scrapeTimeout: 10s
+    # -- Metrics path. The chart prepends spoolman.basePath automatically.
+    path: /metrics
+    # -- Extra labels for the ServiceMonitor (e.g. to match a Prometheus selector)
+    labels: {}
+
+# -- Resource limits and requests
+resources:
+  requests:
+    memory: "128Mi"
+    cpu: "50m"
+  limits:
+    memory: "256Mi"
+    cpu: "500m"
+
+# -- Security context for the pod. fsGroup defaults to pgid so the persistent
+# volume is writable by the application group; set fsGroup here to override.
+podSecurityContext:
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Security context for the container.
+# WARNING: the Spoolman image entrypoint starts as root and drops privileges to
+# UID 1000 via gosu. Do NOT set runAsNonRoot: true or runAsUser here or the
+# container will fail to start. Left empty by default on purpose.
+securityContext: {}
+
+# -- Startup probe. Generous failureThreshold to allow database migrations on
+# first start.
+startupProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  timeoutSeconds: 3
+  failureThreshold: 30
+
+# -- Liveness probe configuration
+livenessProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+
+# -- Readiness probe configuration
+readinessProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+# -- Service account configuration
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use
+  name: ""
+
+# -- Update strategy. Recreate avoids two pods mounting the same ReadWriteOnce
+# volume during a rollout. With a ReadWriteMany volume and replicaCount > 1,
+# switch to RollingUpdate to avoid downtime on every rollout.
+updateStrategy:
+  type: Recreate
+
+# -- Network Policy configuration
+networkPolicy:
+  # -- Enable NetworkPolicy
+  enabled: false
+  # -- Additional ingress rules. The built-in rule allows the http port from all
+  # namespaces, so the default is permissive; tighten access by adding rules here.
+  ingress: []
+  # -- Additional egress rules. Egress to the external database port is added
+  # automatically when database.type is not sqlite.
+  egress: []
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling
+tolerations: []
+
+# -- Affinity rules for pod scheduling
+affinity: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Extra environment variables for the container
+# @default -- []
+extraEnv: []
+# - name: SPOOLMAN_DIR_BACKUPS
+#   value: /home/app/.local/share/spoolman/backups
+
+# -- Init containers to run before the main container
+# @default -- []
+initContainers: []
+
+# -- Extra containers to run alongside Spoolman (sidecars)
+# @default -- []
+extraContainers: []
+
+# -- Extra volumes to add to the pod (raw Kubernetes volume specs)
+# @default -- []
+extraVolumes: []
+
+# -- Extra volume mounts for the container
+# @default -- []
+extraVolumeMounts: []


### PR DESCRIPTION
# Pull Request

## Description

Adds a chart for [Spoolman](https://github.com/Donkie/Spoolman), a self-hosted filament-spool inventory manager for 3D printing. It defaults to the embedded SQLite database on a persistent volume and optionally connects to an external PostgreSQL, MySQL or CockroachDB instance, with the password taken from a chart-managed or pre-existing Secret. Optional Ingress, Gateway API HTTPRoute, NetworkPolicy (with automatic egress to the database port), a Prometheus metrics toggle and a ServiceMonitor are included.

The Spoolman image entrypoint starts as root, remaps PUID/PGID and drops to UID 1000 via gosu. The chart therefore sets `fsGroup` at the pod level and leaves the container security context empty instead of forcing `runAsNonRoot`, which would break startup. This is documented in the values, the README and NOTES.

Secondary change: the issue-template "affected chart" dropdowns only listed four of the repository's charts, so issues could not be filed against the rest. This PR lists all current charts in the three forms and adds a CI job that keeps the dropdowns in sync with `charts/*`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml` (initial version `0.1.0`)
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/spoolman`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/spoolman/values.schema.json charts/spoolman/values.yaml`)
- [x] Helm lint passes (`helm lint charts/spoolman`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [x] Default values maintain existing behavior

## Additional context

App version pinned to Spoolman `0.23.1`. The chart is added to the lint-test CI matrix; `publish-oci.yaml` auto-detects it on merge and publishes the OCI artifact, cosign signature and the `artifacthub-repo.yml` metadata. 52 unit tests cover the Deployment, Service, PVC, Secret, Ingress, HTTPRoute, NetworkPolicy and ServiceMonitor templates.
