### PR TITLE
ci(workflows): pin Helm to v4.2.2 to stop setup-helm fallback flake

### DIFF
--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -103,7 +103,11 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
         with:
-          version: latest
+          # Pinned: `latest` falls back to a baked-in Helm 3 default when the
+          # setup-helm release lookup flakes, and `helm plugin install --verify`
+          # below is a Helm 4-only flag, so that fallback fails the job.
+          # renovate: datasource=github-releases depName=helm/helm
+          version: v4.2.2
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -83,7 +83,11 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
         with:
-          version: 'latest'
+          # Pinned: `latest` falls back to a baked-in Helm 3 default when the
+          # setup-helm release lookup flakes, and `helm plugin install --verify`
+          # below is a Helm 4-only flag, so that fallback fails the job.
+          # renovate: datasource=github-releases depName=helm/helm
+          version: 'v4.2.2'
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Description

`azure/setup-helm@v5` with `version: latest` normally installs the newest Helm release, but when its release lookup flakes (`TypeError: fetch failed`) it falls back to a baked-in Helm 3 default (`v3.18.4`). The `helm plugin install … --verify=false` step is a **Helm 4-only** flag, so on that fallback the job dies with `unknown flag: --verify`. This is a nondeterministic red: most runs resolve Helm 4 and pass, but any per-job GitHub API hiccup flips a chart's lint-test (most recently `lint-test (charts/spoolman)`) to failure even though the chart is fine.

Pin Helm to a fixed version in both `test.yaml` and `publish-oci.yaml` so every job is deterministic and `--verify` is always available. Renovate (`# renovate: datasource=github-releases depName=helm/helm`) keeps it current.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented

## Additional context

The currently-passing chart jobs already run on Helm `v4.2.2` (verified in the failing run's logs), so pinning to it changes nothing for the jobs that pass and removes the fallback that breaks the others. No chart content changed, so no chart version bump.
