### PR TITLE
ci(renovate): extend shared preset and ignore CI bot commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
-  "automerge": true,
-  "platformAutomerge": true,
-  "automergeType": "pr",
-  "automergeStrategy": "squash",
-  "ignoreTests": false,
-  "ignoreDeps": [
-    "ghcr.io/lexfrei/edc-connector"
-  ],
+  "extends": ["github>lexfrei/renovate-config"],
+  "gitIgnoredAuthors": ["github-actions[bot]@users.noreply.github.com"],
+  "ignoreDeps": ["ghcr.io/lexfrei/edc-connector"],
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)Chart\\.yaml$/"
-      ],
+      "managerFilePatterns": ["/(^|/)Chart\\.yaml$/"],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.*?appVersion: \"(?<currentValue>.*?)\""
       ],


### PR DESCRIPTION
Extend the shared `github>lexfrei/renovate-config` preset for common policy.

Add `gitIgnoredAuthors` for `github-actions[bot]`: the `renovate-update` workflow commits the regenerated changelog + helm-docs onto each Renovate branch, which made Renovate treat the branch as externally modified and stop rebasing it. Combined with strict *require-up-to-date* protection, mergeable PRs (e.g. #218) stayed stuck BEHIND indefinitely. Ignoring the bot's commits lets Renovate keep the branch current so auto-merge completes; the changelog commit is reapplied on the next workflow run.