### PR TITLE
feat: default automountServiceAccountToken to false on app charts

### DIFF
--- a/charts/cloudflare-tunnel/Chart.yaml
+++ b/charts/cloudflare-tunnel/Chart.yaml
@@ -3,8 +3,10 @@ annotations:
   # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
   # See: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |-
+    - kind: added
+      description: serviceAccount.automountServiceAccountToken value to control API token automounting
     - kind: changed
-      description: Update cloudflare/cloudflared docker tag to v2026.6.1
+      description: Do not automount the ServiceAccount API token by default, as cloudflared does not use the Kubernetes API
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -18,7 +20,7 @@ apiVersion: v2
 name: cloudflare-tunnel
 description: Creation of a cloudflared deployment - a reverse tunnel for an environment
 type: application
-version: "0.15.11"
+version: "0.16.0"
 kubeVersion: ">=1.21.0-0"
 # renovate: datasource=docker depName=cloudflare/cloudflared
 appVersion: "2026.6.1"

--- a/charts/cloudflare-tunnel/README.md
+++ b/charts/cloudflare-tunnel/README.md
@@ -1,6 +1,6 @@
 # cloudflare-tunnel
 
-![Version: 0.15.11](https://img.shields.io/badge/Version-0.15.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.1](https://img.shields.io/badge/AppVersion-2026.6.1-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.1](https://img.shields.io/badge/AppVersion-2026.6.1-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -69,7 +69,7 @@ Before installing the chart, create a tunnel in Cloudflare:
 # Install with inline configuration
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.15.11 \
+  --version 0.16.0 \
   --set cloudflare.account=YOUR_ACCOUNT_ID \
   --set cloudflare.tunnelName=YOUR_TUNNEL_NAME \
   --set cloudflare.tunnelId=YOUR_TUNNEL_ID \
@@ -80,7 +80,7 @@ helm install cloudflare-tunnel \
 # Install with values file
 helm install cloudflare-tunnel \
   oci://ghcr.io/lexfrei/charts/cloudflare-tunnel \
-  --version 0.15.11 \
+  --version 0.16.0 \
   --values values.yaml
 ```
 
@@ -90,7 +90,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.15.11 \
+  ghcr.io/lexfrei/charts/cloudflare-tunnel:0.16.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -523,6 +523,7 @@ Kubernetes: `>=1.21.0-0`
 | retries | string | `""` | Maximum retries for connection/protocol errors Number of retries cloudflared will attempt for network errors Leave empty to use cloudflared default (5) |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true}` | Security items for one container. We lock it down |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Automount the API token for the service account. cloudflared only proxies traffic and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access. |
 | serviceAccount.name | string | `""` | The name of the service account to use If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.enabled | bool | `false` | Enable prometheus Service Monitor |
 | serviceMonitor.interval | string | `""` | Scrape interval for Prometheus |

--- a/charts/cloudflare-tunnel/templates/serviceaccount.yaml
+++ b/charts/cloudflare-tunnel/templates/serviceaccount.yaml
@@ -10,3 +10,4 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/cloudflare-tunnel/tests/serviceaccount_test.yaml
+++ b/charts/cloudflare-tunnel/tests/serviceaccount_test.yaml
@@ -41,3 +41,29 @@ tests:
       - equal:
           path: metadata.annotations["eks.amazonaws.com/role-arn"]
           value: "arn:aws:iam::123456789012:role/my-role"
+
+  - it: should disable automount by default
+    set:
+      cloudflare:
+        account: "test-account"
+        tunnelName: "test-tunnel"
+        tunnelId: "test-id"
+        secret: "test-secret"
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should honour automount override
+    set:
+      cloudflare:
+        account: "test-account"
+        tunnelName: "test-tunnel"
+        tunnelId: "test-id"
+        secret: "test-secret"
+      serviceAccount:
+        automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true

--- a/charts/cloudflare-tunnel/values.schema.json
+++ b/charts/cloudflare-tunnel/values.schema.json
@@ -194,6 +194,10 @@
     "serviceAccount": {
       "type": "object",
       "properties": {
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Automount the API token for the service account. cloudflared only proxies traffic and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access."
+        },
         "annotations": {
           "type": "object",
           "additionalProperties": {

--- a/charts/cloudflare-tunnel/values.yaml
+++ b/charts/cloudflare-tunnel/values.yaml
@@ -75,6 +75,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 serviceAccount:
+  # -- Automount the API token for the service account. cloudflared only proxies traffic and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access.
+  automountServiceAccountToken: false
   # -- Annotations to add to the service account
   annotations: {}
   # -- The name of the service account to use

--- a/charts/me-site/Chart.yaml
+++ b/charts/me-site/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: me-site
 description: A Helm chart for the Me-Site application
 type: application
-version: 0.5.1
+version: 0.6.0
 appVersion: 1.0.0
 maintainers:
   - name: lexfrei
@@ -11,7 +11,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: added
-      description: "Add schema validation for annotations (must be string values)"
-    - kind: added
-      description: "Add unit test for default annotations"
+      description: "automountServiceAccountToken value to control API token automounting"
+    - kind: changed
+      description: "Do not automount the ServiceAccount API token by default, as me-site does not use the Kubernetes API"
 kubeVersion: '>=1.19.0-0'

--- a/charts/me-site/README.md
+++ b/charts/me-site/README.md
@@ -1,6 +1,6 @@
 # me-site
 
-![Version: 0.5.1](https://img.shields.io/badge/Version-0.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -29,12 +29,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.5.1
+  --version 0.6.0
 
 # Install with custom values
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.5.1 \
+  --version 0.6.0 \
   --values values.yaml
 ```
 
@@ -44,7 +44,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/me-site:0.5.1 \
+  ghcr.io/lexfrei/charts/me-site:0.6.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -59,6 +59,7 @@ helm delete me-site
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| automountServiceAccountToken | bool | `false` | Automount the API token into the pod. me-site serves a static site and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access. |
 | containerPort | int | `8080` |  |
 | httpRoute.annotations | object | `{}` |  |
 | httpRoute.enabled | bool | `false` |  |

--- a/charts/me-site/templates/deployment.yaml
+++ b/charts/me-site/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       labels:
         app: me-site
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/me-site/tests/automount_test.yaml
+++ b/charts/me-site/tests/automount_test.yaml
@@ -1,0 +1,17 @@
+suite: automount service account token tests
+templates:
+  - deployment.yaml
+tests:
+  - it: should disable automount by default
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should honour automount override
+    set:
+      automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true

--- a/charts/me-site/values.schema.json
+++ b/charts/me-site/values.schema.json
@@ -3,6 +3,10 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "automountServiceAccountToken": {
+      "type": "boolean",
+      "description": "Automount the API token into the pod. me-site serves a static site and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access."
+    },
     "nameOverride": {
       "type": "string",
       "description": "Override the name of the chart"

--- a/charts/me-site/values.yaml
+++ b/charts/me-site/values.yaml
@@ -1,3 +1,5 @@
+# -- Automount the API token into the pod. me-site serves a static site and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access.
+automountServiceAccountToken: false
 replicaCount: 1
 image:
   repository: ghcr.io/lexfrei/me-site

--- a/charts/spoolman/Chart.yaml
+++ b/charts/spoolman/Chart.yaml
@@ -1,7 +1,9 @@
 annotations:
   artifacthub.io/changes: |-
     - kind: added
-      description: Initial release of the Spoolman Helm chart
+      description: serviceAccount.automountServiceAccountToken value to control API token automounting
+    - kind: changed
+      description: Do not automount the ServiceAccount API token by default, as Spoolman does not use the Kubernetes API
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -15,7 +17,7 @@ apiVersion: v2
 name: spoolman
 description: Spoolman filament spool inventory management for 3D printing, packaged for Kubernetes
 type: application
-version: "0.1.0"
+version: "0.2.0"
 # renovate: datasource=docker depName=ghcr.io/donkie/spoolman
 appVersion: "0.23.1"
 icon: https://raw.githubusercontent.com/Donkie/Spoolman/master/client/public/pwa-512x512.png

--- a/charts/spoolman/README.md
+++ b/charts/spoolman/README.md
@@ -1,6 +1,6 @@
 # spoolman
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.1](https://img.shields.io/badge/AppVersion-0.23.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.23.1](https://img.shields.io/badge/AppVersion-0.23.1-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -36,12 +36,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install spoolman \
   oci://ghcr.io/lexfrei/charts/spoolman \
-  --version 0.1.0
+  --version 0.2.0
 
 # Install with custom values
 helm install spoolman \
   oci://ghcr.io/lexfrei/charts/spoolman \
-  --version 0.1.0 \
+  --version 0.2.0 \
   --values values.yaml
 ```
 
@@ -51,7 +51,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/spoolman:0.1.0 \
+  ghcr.io/lexfrei/charts/spoolman:0.2.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -130,8 +130,9 @@ The Spoolman image entrypoint starts as `root`, remaps `PUID`/`PGID` and then dr
 | service.annotations | object | `{}` | Service annotations |
 | service.port | int | `80` | Service port (mapped to the container's http port 8000) |
 | service.type | string | `"ClusterIP"` | Service type |
-| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Service account configuration |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"create":true,"name":""}` | Service account configuration |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Automount the API token for the service account. Spoolman does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use |
 | spoolman | object | `{"automaticBackup":true,"basePath":"","corsOrigin":"","loggingLevel":""}` | Application-level settings, mapped to SPOOLMAN_* environment variables |

--- a/charts/spoolman/templates/serviceaccount.yaml
+++ b/charts/spoolman/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/spoolman/tests/serviceaccount_test.yaml
+++ b/charts/spoolman/tests/serviceaccount_test.yaml
@@ -1,0 +1,29 @@
+suite: serviceaccount tests
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: should create ServiceAccount by default
+    asserts:
+      - isKind:
+          of: ServiceAccount
+
+  - it: should not create ServiceAccount when disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should disable automount by default
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should honour automount override
+    set:
+      serviceAccount.automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true

--- a/charts/spoolman/values.schema.json
+++ b/charts/spoolman/values.schema.json
@@ -483,6 +483,10 @@
           "type": "boolean",
           "description": "Specifies whether a service account should be created"
         },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Automount the API token for the service account. Spoolman does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access."
+        },
         "annotations": {
           "type": "object",
           "additionalProperties": {

--- a/charts/spoolman/values.yaml
+++ b/charts/spoolman/values.yaml
@@ -190,6 +190,8 @@ readinessProbe:
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
+  # -- Automount the API token for the service account. Spoolman does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access.
+  automountServiceAccountToken: false
   # -- Annotations to add to the service account
   annotations: {}
   # -- The name of the service account to use

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -1,8 +1,10 @@
 annotations:
   artifacthub.io/category: storage
   artifacthub.io/changes: |-
+    - kind: added
+      description: serviceAccount.automountServiceAccountToken value to control API token automounting
     - kind: changed
-      description: Update linuxserver/transmission docker tag to v4.1.3
+      description: Do not automount the ServiceAccount API token by default, as Transmission does not use the Kubernetes API
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +18,7 @@ apiVersion: v2
 name: transmission
 description: Transmission BitTorrent client Helm chart for Kubernetes
 type: application
-version: "1.7.4"
+version: "1.8.0"
 # renovate: datasource=docker depName=linuxserver/transmission
 appVersion: "4.1.3"
 icon: https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission-icon.png

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -1,6 +1,6 @@
 # transmission
 
-![Version: 1.7.4](https://img.shields.io/badge/Version-1.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.3](https://img.shields.io/badge/AppVersion-4.1.3-informational?style=flat-square)
+![Version: 1.8.0](https://img.shields.io/badge/Version-1.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.1.3](https://img.shields.io/badge/AppVersion-4.1.3-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -38,12 +38,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.7.4
+  --version 1.8.0
 
 # Install with custom values
 helm install transmission \
   oci://ghcr.io/lexfrei/charts/transmission \
-  --version 1.7.4 \
+  --version 1.8.0 \
   --values values.yaml
 ```
 
@@ -53,7 +53,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/transmission:1.7.4 \
+  ghcr.io/lexfrei/charts/transmission:1.8.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -136,8 +136,9 @@ helm delete transmission
 | service.web.annotations | object | `{}` | Annotations for Web UI service |
 | service.web.port | int | `9091` | HTTP port |
 | service.web.type | string | `"ClusterIP"` | Service type for Web UI |
-| serviceAccount | object | `{"annotations":{},"create":true,"name":""}` | Service account configuration |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":false,"create":true,"name":""}` | Service account configuration |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.automountServiceAccountToken | bool | `false` | Automount the API token for the service account. Transmission does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access. |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use |
 | terminationGracePeriodSeconds | string | Kubernetes default (30 seconds) | Duration in seconds the pod needs to terminate gracefully |

--- a/charts/transmission/templates/serviceaccount.yaml
+++ b/charts/transmission/templates/serviceaccount.yaml
@@ -9,4 +9,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/transmission/tests/serviceaccount_test.yaml
+++ b/charts/transmission/tests/serviceaccount_test.yaml
@@ -1,0 +1,29 @@
+suite: serviceaccount tests
+templates:
+  - templates/serviceaccount.yaml
+tests:
+  - it: should create ServiceAccount by default
+    asserts:
+      - isKind:
+          of: ServiceAccount
+
+  - it: should not create ServiceAccount when disabled
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should disable automount by default
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: should honour automount override
+    set:
+      serviceAccount.automountServiceAccountToken: true
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true

--- a/charts/transmission/values.schema.json
+++ b/charts/transmission/values.schema.json
@@ -488,6 +488,10 @@
           "type": "boolean",
           "description": "Specifies whether a service account should be created"
         },
+        "automountServiceAccountToken": {
+          "type": "boolean",
+          "description": "Automount the API token for the service account. Transmission does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access."
+        },
         "annotations": {
           "type": "object",
           "additionalProperties": {

--- a/charts/transmission/values.yaml
+++ b/charts/transmission/values.yaml
@@ -186,6 +186,8 @@ podLabels: {}
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
+  # -- Automount the API token for the service account. Transmission does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access.
+  automountServiceAccountToken: false
   # -- Annotations to add to the service account
   annotations: {}
   # -- The name of the service account to use

--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -1,8 +1,10 @@
 annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
+    - kind: added
+      description: automountServiceAccountToken value to control API token automounting
     - kind: changed
-      description: Update alpine docker tag to v3.24
+      description: Do not automount the ServiceAccount API token by default, as vipalived does not use the Kubernetes API
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -16,7 +18,7 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.7.1
+version: 0.8.0
 # renovate: datasource=docker depName=alpine
 appVersion: "3.24"
 keywords:

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -1,6 +1,6 @@
 # vipalived
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.24](https://img.shields.io/badge/AppVersion-3.24-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.24](https://img.shields.io/badge/AppVersion-3.24-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -16,16 +16,16 @@ Keepalived-based VIP management for Kubernetes control plane high availability
 
 ```bash
 # Day 2: Install with default VIP (172.16.101.101/32) on existing cluster
-helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.7.1
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.8.0
 
 # Day 2: Install with custom VIP address
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.7.1 \
+  --version 0.8.0 \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
 
 # Day 1: Generate static pod manifest for cluster bootstrap
 helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.7.1 \
+  --version 0.8.0 \
   --set static=true \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
 ```
@@ -75,7 +75,7 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 
    ```bash
    helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-     --version 0.7.1 \
+     --version 0.8.0 \
      --set static=true \
      --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR \
      --namespace kube-system > vipalived-static-pod.yaml
@@ -152,7 +152,7 @@ All charts published to GHCR are signed using cosign. To verify the chart signat
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/vipalived:0.7.1 \
+  ghcr.io/lexfrei/charts/vipalived:0.8.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -162,6 +162,7 @@ cosign verify \
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity rules for pod assignment (DaemonSet mode only). Ignored when `static: true` — static pods use `staticAffinity` instead. |
+| automountServiceAccountToken | bool | `false` | Automount the API token into the pod. vipalived manages a VIP via keepalived and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access. |
 | fullnameOverride | string | `""` | Override the full name of the chart |
 | hostNetwork | bool | `true` | Enable host network mode (required for VIP functionality) |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |

--- a/charts/vipalived/templates/daemonset.yaml
+++ b/charts/vipalived/templates/daemonset.yaml
@@ -29,6 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       hostNetwork: {{ .Values.hostNetwork }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/vipalived/templates/pod.yaml
+++ b/charts/vipalived/templates/pod.yaml
@@ -14,6 +14,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
   hostNetwork: {{ .Values.hostNetwork }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets:

--- a/charts/vipalived/tests/automount_test.yaml
+++ b/charts/vipalived/tests/automount_test.yaml
@@ -1,0 +1,35 @@
+suite: automount service account token tests
+templates:
+  - daemonset.yaml
+  - pod.yaml
+  - configmap.yaml
+tests:
+  - it: should disable automount on the DaemonSet by default
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: should honour automount override on the DaemonSet
+    set:
+      automountServiceAccountToken: true
+    asserts:
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+
+  - it: should disable automount on the static Pod by default
+    set:
+      static: true
+      keepalived:
+        routerId: test-router
+        vrrpVersion: 3
+        vrrpInstance:
+          virtualIpAddress: 192.168.1.100/24
+    asserts:
+      - template: pod.yaml
+        equal:
+          path: spec.automountServiceAccountToken
+          value: false

--- a/charts/vipalived/values.schema.json
+++ b/charts/vipalived/values.schema.json
@@ -20,6 +20,11 @@
       "description": "Enable static pod mode for Day 1 cluster bootstrap. When true, renders a Pod manifest instead of DaemonSet with embedded configuration.",
       "default": false
     },
+    "automountServiceAccountToken": {
+      "type": "boolean",
+      "description": "Automount the API token into the pod. vipalived manages a VIP via keepalived and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access.",
+      "default": false
+    },
     "image": {
       "type": "object",
       "properties": {

--- a/charts/vipalived/values.yaml
+++ b/charts/vipalived/values.yaml
@@ -17,6 +17,9 @@ namespace: kube-system
 # For Day 2 operations (existing cluster), keep this false (default).
 static: false
 
+# -- Automount the API token into the pod. vipalived manages a VIP via keepalived and does not talk to the Kubernetes API, so this defaults to false; set true only if your deployment needs API access.
+automountServiceAccountToken: false
+
 image:
   # -- Container image repository
   repository: alpine


### PR DESCRIPTION
## Description

These app-type charts run workloads that never call the Kubernetes API, yet every pod still gets a ServiceAccount token auto-mounted at `/var/run/secrets/kubernetes.io/serviceaccount`. Since none of these charts ship RBAC, that token grants nothing useful and is pure attack surface. This makes token automounting a configurable value that defaults to **false** across the five app charts that lacked it, so a fresh install is least-privilege by default while still allowing opt-in for anyone who needs API access.

Charts changed (old to new version):

- `spoolman` 0.1.0 -> 0.2.0 (ServiceAccount-level)
- `transmission` 1.7.4 -> 1.8.0 (ServiceAccount-level)
- `cloudflare-tunnel` 0.15.11 -> 0.16.0 (ServiceAccount-level)
- `me-site` 0.5.1 -> 0.6.0 (pod-level)
- `vipalived` 0.7.1 -> 0.8.0 (pod-level)

Wiring convention:

- Charts that create their own ServiceAccount (`spoolman`, `transmission`, `cloudflare-tunnel`) set `automountServiceAccountToken` on the ServiceAccount object via a new `serviceAccount.automountServiceAccountToken` value (default false). A pod can still override it to true.
- Charts that have no ServiceAccount and run on the namespace default SA (`me-site`, `vipalived`) set `automountServiceAccountToken` on the pod template via a new top-level `automountServiceAccountToken` value (default false). For `vipalived` this covers both the DaemonSet and the static Pod.

Controllers were intentionally left alone: `system-upgrade-controller` and `extractedprism` ship their own RBAC and genuinely need the token, so they keep automounting. `obico` and `eclipse-edc` already disable automounting.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/<chart-name>`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/<chart-name>/values.schema.json charts/<chart-name>/values.yaml`)
- [x] Helm lint passes (`helm lint charts/<chart-name>`)

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [ ] Default values maintain existing behavior

## Additional context

The default changes from auto-mounting the token to not mounting it, so the "default values maintain existing behavior" box is intentionally left unchecked. This is a deliberate secure-by-default change. It is safe for these charts because none of the workloads use the Kubernetes API; anyone who does need API access can set the value back to true.
