### PR TITLE
feat(vipalived): consume prebuilt keepalived image for airgap

### DIFF
--- a/charts/vipalived/Chart.yaml
+++ b/charts/vipalived/Chart.yaml
@@ -1,14 +1,18 @@
 annotations:
   artifacthub.io/category: networking
   artifacthub.io/changes: |-
-    - kind: added
-      description: automountServiceAccountToken value to control API token automounting
     - kind: changed
-      description: Do not automount the ServiceAccount API token by default, as vipalived does not use the Kubernetes API
+      description: Use a prebuilt keepalived image (ghcr.io/lexfrei/keepalived) instead of installing keepalived with apk at container startup, so the chart works in airgapped clusters
+    - kind: changed
+      description: appVersion now tracks the keepalived version instead of the Alpine base version
+    - kind: fixed
+      description: Static pod mode could not write its config because /etc/keepalived did not exist; the image now creates it and the pod ensures it before writing
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
       url: https://github.com/lexfrei/charts/
+    - name: Container Images
+      url: https://github.com/lexfrei/images/
     - name: Keepalived
       url: https://www.keepalived.org/
   artifacthub.io/signKey: |
@@ -18,9 +22,9 @@ apiVersion: v2
 name: vipalived
 description: Keepalived-based VIP management for Kubernetes control plane high availability
 type: application
-version: 0.8.0
-# renovate: datasource=docker depName=alpine
-appVersion: "3.24"
+version: 0.9.0
+# renovate: datasource=docker depName=ghcr.io/lexfrei/keepalived
+appVersion: "2.3.4"
 keywords:
   - keepalived
   - vrrp

--- a/charts/vipalived/README.md
+++ b/charts/vipalived/README.md
@@ -1,6 +1,6 @@
 # vipalived
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.24](https://img.shields.io/badge/AppVersion-3.24-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.3.4](https://img.shields.io/badge/AppVersion-2.3.4-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -16,23 +16,23 @@ Keepalived-based VIP management for Kubernetes control plane high availability
 
 ```bash
 # Day 2: Install with default VIP (172.16.101.101/32) on existing cluster
-helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.8.0
+helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived --version 0.9.0
 
 # Day 2: Install with custom VIP address
 helm install my-vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.8.0 \
+  --version 0.9.0 \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24
 
 # Day 1: Generate static pod manifest for cluster bootstrap
 helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-  --version 0.8.0 \
+  --version 0.9.0 \
   --set static=true \
   --set keepalived.vrrpInstance.virtualIpAddress=192.168.1.100/24 > /etc/kubernetes/manifests/vipalived.yaml
 ```
 
 ## Introduction
 
-This chart deploys keepalived as a DaemonSet on Kubernetes control plane nodes to provide Virtual IP (VIP) functionality for high availability. It uses VRRP (Virtual Router Redundancy Protocol) to manage IP failover between control plane nodes.
+This chart deploys keepalived as a DaemonSet on Kubernetes control plane nodes to provide Virtual IP (VIP) functionality for high availability. It uses VRRP (Virtual Router Redundancy Protocol) to manage IP failover between control plane nodes. keepalived ships in a prebuilt image (`ghcr.io/lexfrei/keepalived`) with nothing installed at container startup, so the chart runs in airgapped environments.
 
 **Target Audience**: This chart is for users who prefer Kubernetes-native solutions with minimal system intrusion, but need a VIP for the kube-apiserver available before CNI initialization. Unlike kube-vip, Cilium, or other solutions that require CNI or complex integrations, this provides a simple, focused solution specifically for control plane VIP management during cluster bootstrap (Day 1) and beyond (Day 2).
 
@@ -75,7 +75,7 @@ For **Day 1 cluster bootstrapping**, when you need the VIP available BEFORE the 
 
    ```bash
    helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
-     --version 0.8.0 \
+     --version 0.9.0 \
      --set static=true \
      --set keepalived.vrrpInstance.virtualIpAddress=YOUR_VIP_ADDRESS/CIDR \
      --namespace kube-system > vipalived-static-pod.yaml
@@ -152,7 +152,7 @@ All charts published to GHCR are signed using cosign. To verify the chart signat
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/vipalived:0.8.0 \
+  ghcr.io/lexfrei/charts/vipalived:0.9.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -166,7 +166,7 @@ cosign verify \
 | fullnameOverride | string | `""` | Override the full name of the chart |
 | hostNetwork | bool | `true` | Enable host network mode (required for VIP functionality) |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"alpine"` | Container image repository |
+| image.repository | string | `"ghcr.io/lexfrei/keepalived"` | Container image repository. Prebuilt keepalived image (keepalived baked in, no install at startup) so the chart works in airgapped clusters. |
 | image.tag | string | `""` | Container image tag (defaults to chart appVersion if not set) |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
 | keepalived.garp.masterDelay | int | `5` | Delay for gratuitous ARP after master transition |
@@ -186,12 +186,12 @@ cosign verify \
 | keepalived.vrrpInstance.virtualIpAddress | string | `"172.16.101.101/32"` | Virtual IP address with CIDR notation |
 | keepalived.vrrpInstance.virtualRouterId | int | `51` | Virtual router ID (must be unique in the network) |
 | keepalived.vrrpVersion | int | `3` | VRRP protocol version (2 or 3) |
-| livenessProbe | object | `{"enabled":true,"exec":{"command":["pgrep","keepalived"]},"failureThreshold":3,"initialDelaySeconds":15,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
+| livenessProbe | object | `{"enabled":true,"exec":{"command":["pgrep","keepalived"]},"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":5}` | Liveness probe configuration |
 | livenessProbe.enabled | bool | `true` | Enable liveness probe |
 | livenessProbe.exec | object | `{"command":["pgrep","keepalived"]}` | Exec probe configuration |
 | livenessProbe.exec.command | list | `["pgrep","keepalived"]` | Command to execute for the probe |
 | livenessProbe.failureThreshold | int | `3` | Failure threshold for liveness probe |
-| livenessProbe.initialDelaySeconds | int | `15` | Initial delay before liveness probe starts |
+| livenessProbe.initialDelaySeconds | int | `5` | Initial delay before liveness probe starts. keepalived is baked into the image and starts immediately (no apk install). |
 | livenessProbe.periodSeconds | int | `10` | Period between liveness probe checks |
 | livenessProbe.timeoutSeconds | int | `5` | Timeout for liveness probe |
 | nameOverride | string | `""` | Override the name of the chart |
@@ -294,6 +294,7 @@ tolerations:
 
 ## Important Notes
 
+- **Container image**: keepalived is baked into a prebuilt, multi-arch image (`ghcr.io/lexfrei/keepalived`, built from [lexfrei/images](https://github.com/lexfrei/images/)). Nothing is installed at container startup, so the chart works in airgapped clusters — mirror the image into your registry and point `image.repository` at it.
 - **Host Network**: This chart requires `hostNetwork: true` to function correctly. The VIP must be accessible on the host network.
 - **Security**: The container requires `NET_ADMIN`, `NET_RAW`, and `NET_BROADCAST` capabilities to manage network interfaces and VRRP.
 - **Priority Class**: Uses `system-node-critical` to ensure the DaemonSet is scheduled even under resource pressure.

--- a/charts/vipalived/README.md.gotmpl
+++ b/charts/vipalived/README.md.gotmpl
@@ -32,7 +32,7 @@ helm template vipalived oci://ghcr.io/lexfrei/charts/vipalived \
 
 ## Introduction
 
-This chart deploys keepalived as a DaemonSet on Kubernetes control plane nodes to provide Virtual IP (VIP) functionality for high availability. It uses VRRP (Virtual Router Redundancy Protocol) to manage IP failover between control plane nodes.
+This chart deploys keepalived as a DaemonSet on Kubernetes control plane nodes to provide Virtual IP (VIP) functionality for high availability. It uses VRRP (Virtual Router Redundancy Protocol) to manage IP failover between control plane nodes. keepalived ships in a prebuilt image (`ghcr.io/lexfrei/keepalived`) with nothing installed at container startup, so the chart runs in airgapped environments.
 
 **Target Audience**: This chart is for users who prefer Kubernetes-native solutions with minimal system intrusion, but need a VIP for the kube-apiserver available before CNI initialization. Unlike kube-vip, Cilium, or other solutions that require CNI or complex integrations, this provides a simple, focused solution specifically for control plane VIP management during cluster bootstrap (Day 1) and beyond (Day 2).
 
@@ -227,6 +227,7 @@ tolerations:
 
 ## Important Notes
 
+- **Container image**: keepalived is baked into a prebuilt, multi-arch image (`ghcr.io/lexfrei/keepalived`, built from [lexfrei/images](https://github.com/lexfrei/images/)). Nothing is installed at container startup, so the chart works in airgapped clusters — mirror the image into your registry and point `image.repository` at it.
 - **Host Network**: This chart requires `hostNetwork: true` to function correctly. The VIP must be accessible on the host network.
 - **Security**: The container requires `NET_ADMIN`, `NET_RAW`, and `NET_BROADCAST` capabilities to manage network interfaces and VRRP.
 - **Priority Class**: Uses `system-node-critical` to ensure the DaemonSet is scheduled even under resource pressure.

--- a/charts/vipalived/questions.yaml
+++ b/charts/vipalived/questions.yaml
@@ -186,9 +186,9 @@ questions:
 # Image Configuration
 - variable: image.repository
   label: Image Repository
-  description: Docker image repository
+  description: Prebuilt keepalived image repository (keepalived baked in, airgap-ready)
   type: string
-  default: alpine
+  default: ghcr.io/lexfrei/keepalived
   required: true
   group: "Image Configuration"
 - variable: image.tag

--- a/charts/vipalived/templates/daemonset.yaml
+++ b/charts/vipalived/templates/daemonset.yaml
@@ -58,12 +58,14 @@ spec:
         - name: keepalived
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # keepalived is baked into the image; exec it directly (config is
+          # mounted from the ConfigMap at /etc/keepalived) so it runs as PID 1.
           command:
-            - /bin/sh
-            - -c
-            - |
-              apk add --no-cache keepalived
-              keepalived --dont-fork --log-console --log-detail --dump-conf
+            - keepalived
+            - --dont-fork
+            - --log-console
+            - --log-detail
+            - --dump-conf
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/charts/vipalived/templates/pod.yaml
+++ b/charts/vipalived/templates/pod.yaml
@@ -52,15 +52,19 @@ spec:
     - name: keepalived
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
       imagePullPolicy: {{ .Values.image.pullPolicy }}
+      # keepalived is baked into the image. A static pod has no ConfigMap (the
+      # API server isn't up on Day 1), so write the config inline via heredoc,
+      # then exec keepalived. mkdir guards against images that don't ship the
+      # /etc/keepalived directory the heredoc writes into.
       command:
         - /bin/sh
         - -c
         - |
-          apk add --no-cache keepalived
+          mkdir -p /etc/keepalived
           cat > /etc/keepalived/keepalived.conf <<'EOF'
           {{- include "vipalived.keepalivedConfig" . | nindent 10 }}
           EOF
-          keepalived --dont-fork --log-console --log-detail --dump-conf
+          exec keepalived --dont-fork --log-console --log-detail --dump-conf
       {{- with .Values.securityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/charts/vipalived/tests/daemonset_test.yaml
+++ b/charts/vipalived/tests/daemonset_test.yaml
@@ -108,7 +108,7 @@ tests:
       - template: daemonset.yaml
         matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^alpine:.+$
+          pattern: ^ghcr\.io/lexfrei/keepalived:.+$
       - template: daemonset.yaml
         equal:
           path: spec.template.spec.containers[0].imagePullPolicy
@@ -117,12 +117,30 @@ tests:
   - it: should use custom image tag when provided
     set:
       image:
-        tag: "3.20"
+        tag: "1.2.3"
     asserts:
       - template: daemonset.yaml
         equal:
           path: spec.template.spec.containers[0].image
-          value: alpine:3.20
+          value: ghcr.io/lexfrei/keepalived:1.2.3
+
+  - it: should run keepalived directly from the baked image without apk install
+    asserts:
+      # Airgap regression guard: the container must exec keepalived straight from
+      # the prebuilt image, never shell out to `apk add` at startup.
+      - template: daemonset.yaml
+        equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - keepalived
+            - --dont-fork
+            - --log-console
+            - --log-detail
+            - --dump-conf
+      - template: daemonset.yaml
+        notContains:
+          path: spec.template.spec.containers[0].command
+          content: /bin/sh
 
   - it: should mount config volume
     asserts:
@@ -296,7 +314,7 @@ tests:
       - template: daemonset.yaml
         equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
-          value: 15
+          value: 5
       - template: daemonset.yaml
         equal:
           path: spec.template.spec.containers[0].livenessProbe.periodSeconds

--- a/charts/vipalived/tests/pod_test.yaml
+++ b/charts/vipalived/tests/pod_test.yaml
@@ -52,6 +52,21 @@ tests:
       - matchRegex:
           path: spec.containers[0].command[2]
           pattern: "192.168.1.100/24"
+      # Airgap regression guard: the static pod writes its config and runs
+      # keepalived from the baked image — it must never `apk add` at startup,
+      # and must ensure the config directory exists before the heredoc write.
+      - notMatchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "apk add"
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "mkdir -p /etc/keepalived"
+      # exec so keepalived replaces the shell as PID 1 and receives SIGTERM
+      # directly for a clean VIP teardown, regardless of the shell's exec
+      # optimization or the image's shell.
+      - matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: "exec keepalived --dont-fork"
 
   - it: should use hostNetwork
     set:
@@ -86,12 +101,11 @@ tests:
     set:
       static: true
       image:
-        repository: alpine
         tag: "test-tag"
     asserts:
       - equal:
           path: spec.containers[0].image
-          value: alpine:test-tag
+          value: ghcr.io/lexfrei/keepalived:test-tag
 
   - it: should not have ConfigMap volumes
     set:
@@ -267,7 +281,7 @@ tests:
           value: keepalived
       - equal:
           path: spec.containers[0].livenessProbe.initialDelaySeconds
-          value: 15
+          value: 5
       - equal:
           path: spec.containers[0].livenessProbe.periodSeconds
           value: 10

--- a/charts/vipalived/values.yaml
+++ b/charts/vipalived/values.yaml
@@ -21,8 +21,9 @@ static: false
 automountServiceAccountToken: false
 
 image:
-  # -- Container image repository
-  repository: alpine
+  # -- Container image repository. Prebuilt keepalived image (keepalived baked in,
+  # no install at startup) so the chart works in airgapped clusters.
+  repository: ghcr.io/lexfrei/keepalived
   # -- Image pull policy
   pullPolicy: IfNotPresent
   # -- Container image tag (defaults to chart appVersion if not set)
@@ -165,8 +166,9 @@ livenessProbe:
     command:
       - pgrep
       - keepalived
-  # -- Initial delay before liveness probe starts
-  initialDelaySeconds: 15
+  # -- Initial delay before liveness probe starts.
+  # keepalived is baked into the image and starts immediately (no apk install).
+  initialDelaySeconds: 5
   # -- Period between liveness probe checks
   periodSeconds: 10
   # -- Timeout for liveness probe


### PR DESCRIPTION
# Pull Request

## Description

Switches the vipalived chart from "plain `alpine` + `apk add keepalived` at container start" to the prebuilt `ghcr.io/lexfrei/keepalived` image, so the chart works in airgapped clusters (nothing is installed at pod startup). `appVersion` now tracks the keepalived version (`2.3.4`) instead of the Alpine base version.

Also fixes and improves two things along the way:

- Static pod mode wrote its config into `/etc/keepalived/`, which the keepalived apk package does not create — the directory was missing and the heredoc write failed. The image now creates it and the pod ensures it before writing (`mkdir -p`).
- keepalived now runs as PID 1 in both modes (DaemonSet execs it directly; static pod uses `exec`), so it receives SIGTERM directly for a clean VIP teardown.

The image is built and published from `lexfrei/images` (multi-arch amd64 + arm64, cosign-signed).

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml` (0.8.0 → 0.9.0)
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added) — N/A, no new values
- [x] `README.md` has been updated
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/vipalived` — 104/104)
- [x] Schema validation passes
- [x] Helm lint passes

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [ ] Default values maintain existing behavior

## Additional context

Default `image.repository` changes from `alpine` to `ghcr.io/lexfrei/keepalived`. Default-config users get the same keepalived VIP behavior (only the image source changes). The break affects users who overrode `image.repository` to a bare-alpine mirror and relied on the startup `apk add`: after upgrading they must point `image.repository` at a keepalived image. This is called out in the changelog and the README "Important Notes" migration note. For a pre-1.0 chart, the minor bump carrying this is semver-compliant.

Airgap regression is pinned by tests in both modes: the container must exec keepalived from the baked image and must never `apk add` at startup.
