### PR TITLE
feat(obico): split ml-api into CPU and GPU image variants

### DIFF
--- a/charts/obico/Chart.yaml
+++ b/charts/obico/Chart.yaml
@@ -3,8 +3,22 @@ annotations:
   # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
   # See: https://artifacthub.io/docs/topics/annotations/helm/
   artifacthub.io/changes: |-
+    - kind: added
+      description: mlApi.gpu switch to run the CUDA GPU inference image instead of the default slim CPU image
+    - kind: added
+      description: mlApi.externalHost to keep ML_API_HOST set when the bundled ml-api is disabled
     - kind: changed
-      description: Document that a connection pooler must run in transaction pooling mode (Obico's CONN_MAX_AGE pins idle connections, exhausting a session-mode pool)
+      description: "Split the ml-api image into CPU and GPU variants (image.mlApi.cpu / image.mlApi.gpu); the slim CPU image is now the default (BREAKING: image.mlApi.repository/tag and the obico-ml-api image are replaced by obico-ml-api-cpu / obico-ml-api-gpu)"
+    - kind: fixed
+      description: Write the Celery beat schedule to the writable /data volume so the non-root worker no longer crashes on startup
+    - kind: fixed
+      description: Mount the static emptyDir before the nested media PVC so uploads are not shadowed and lost on restart
+    - kind: fixed
+      description: Reserve room in the fullname helper so component suffixes keep resource names within the 63-char limit for long release names
+    - kind: fixed
+      description: Preserve an explicit HTTPRoute backendRef weight of 0 and omit matches for catch-all rules
+    - kind: security
+      description: Drop capabilities and block privilege escalation on the collectstatic init container
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -20,7 +34,7 @@ apiVersion: v2
 name: obico
 description: Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper)
 type: application
-version: "0.2.1"
+version: "0.3.0"
 # renovate: datasource=docker depName=ghcr.io/lexfrei/obico-web
 # CalVer derived from the obico-server release commit date (see lexfrei/images).
 appVersion: "2026.1.20"

--- a/charts/obico/README.md
+++ b/charts/obico/README.md
@@ -1,6 +1,6 @@
 # obico
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.20](https://img.shields.io/badge/AppVersion-2026.1.20-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.20](https://img.shields.io/badge/AppVersion-2026.1.20-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -29,7 +29,7 @@ The container images are built from obico-server source and published to GHCR ([
 
 ## Images and auto-update
 
-Obico upstream does not publish ready-to-run images, so they are built from source in a separate repository. Both `obico-web` and `obico-ml-api` are built from one obico commit and share a single calendar-version tag (the chart `appVersion`). Renovate watches the image tag and bumps the chart automatically.
+Obico upstream does not publish ready-to-run images, so they are built from source in a separate repository. Three images — `obico-web`, `obico-ml-api-cpu` and `obico-ml-api-gpu` — are built from one obico commit and share a single calendar-version tag (the chart `appVersion`). Renovate watches the image tag and bumps the chart automatically.
 
 ## Maintainers
 
@@ -55,12 +55,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install obico \
   oci://ghcr.io/lexfrei/charts/obico \
-  --version 0.2.1
+  --version 0.3.0
 
 # Install with custom values
 helm install obico \
   oci://ghcr.io/lexfrei/charts/obico \
-  --version 0.2.1 \
+  --version 0.3.0 \
   --values values.yaml
 ```
 
@@ -70,7 +70,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/obico:0.2.1 \
+  ghcr.io/lexfrei/charts/obico:0.3.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -178,15 +178,24 @@ The web pod runs a single replica because the default SQLite database lives on a
 
 The bundled Redis (`redis.enabled: true`) is a minimal, **unauthenticated** single instance intended for in-cluster use only. Do not expose it outside the cluster. For a hardened or shared Redis, set `redis.enabled: false` and point `redis.externalUrl` at your own instance.
 
-## ML inference image (GPU / CPU)
+## ML inference image (CPU / GPU)
 
-The `ml-api` service currently uses a single image with GPU support baked in — it is built on the upstream CUDA base, so the CUDA / cuDNN runtime libraries ship inside it.
+The `ml-api` service ships as two images built from the same source:
 
-On a node without a GPU it transparently falls back to CPU inference: Obico tries the GPU model first, the CUDA load fails (the NVIDIA driver libraries are not present in the image), and it drops to the CPU path automatically. No configuration is required — it just works, only slower than on a GPU.
+* **CPU (default)** — `obico-ml-api-cpu`, a slim image that runs failure detection on the CPU via ONNX Runtime. No CUDA layers and no NVIDIA toolchain, an order of magnitude smaller than the GPU image (~1 GB vs ~7–8 GB on disk). This is what the chart deploys by default and it runs on any node.
+* **GPU** — `obico-ml-api-gpu`, the CUDA image for NVIDIA GPU inference. Much larger, since the CUDA / cuDNN runtime ships inside it.
 
-On a node with an NVIDIA GPU (device plugin and container runtime configured), schedule `ml-api` there via `nodeSelector` / `tolerations` and an `nvidia.com/gpu` resource limit, and it uses the GPU.
+Most self-hosted deployments run CPU inference and should keep the default. Enable the GPU image only if you have an NVIDIA GPU with the device plugin configured:
 
-The trade-off is size: the CUDA layers make the `ml-api` image large (~3 GB compressed), and on a CPU-only deployment that weight is never exercised. If image size matters for you, open an issue and a slimmer CPU-only image variant will be added. To skip AI failure detection entirely, set `mlApi.enabled: false`.
+```yaml
+mlApi:
+  gpu: true
+  # Adjust for non-NVIDIA / MIG / time-sliced GPUs.
+  gpuResources:
+    nvidia.com/gpu: 1
+```
+
+When `gpu` is true the chart uses the CUDA image and adds `gpuResources` to the container limits, so the scheduler places the pod on a GPU node. To skip AI failure detection entirely, set `mlApi.enabled: false` — but note that Obico still calls the ML API for any printer with detection enabled, so also turn detection off per printer or point `mlApi.externalHost` at an external instance, otherwise those picture uploads will error.
 
 ## Values
 
@@ -208,16 +217,22 @@ The trade-off is size: the CUDA layers make the `ml-api` image large (~3 GB comp
 | httpRoute.hostnames | list | `["obico.example.com"]` | Hostnames for the route |
 | httpRoute.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Parent Gateway references |
 | httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules |
-| image | object | `{"mlApi":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-ml-api","tag":""},"web":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-web","tag":""}}` | Container images. Built from obico-server source and published to GHCR. Both images share the chart appVersion tag (one obico commit -> one tag). |
-| image.mlApi | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-ml-api","tag":""}` | ML inference API image (failure detection) |
-| image.mlApi.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
+| image | object | `{"mlApi":{"cpu":{"repository":"ghcr.io/lexfrei/obico-ml-api-cpu","tag":""},"gpu":{"repository":"ghcr.io/lexfrei/obico-ml-api-gpu","tag":""},"pullPolicy":"IfNotPresent"},"web":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-web","tag":""}}` | Container images. Built from obico-server source and published to GHCR; all share the chart appVersion tag (one obico commit -> one tag). |
+| image.mlApi | object | `{"cpu":{"repository":"ghcr.io/lexfrei/obico-ml-api-cpu","tag":""},"gpu":{"repository":"ghcr.io/lexfrei/obico-ml-api-gpu","tag":""},"pullPolicy":"IfNotPresent"}` | ML inference API images. Two variants are published from the same source: a slim CPU-only image (default) and a CUDA image for GPU inference. mlApi.gpu selects which one runs; configure each variant independently. |
+| image.mlApi.cpu | object | `{"repository":"ghcr.io/lexfrei/obico-ml-api-cpu","tag":""}` | CPU-only inference image (slim). Used when mlApi.gpu is false. |
+| image.mlApi.cpu.tag | string | `""` | Overrides the CPU image tag whose default is the chart appVersion |
+| image.mlApi.gpu | object | `{"repository":"ghcr.io/lexfrei/obico-ml-api-gpu","tag":""}` | CUDA inference image (large). Used when mlApi.gpu is true. |
+| image.mlApi.gpu.tag | string | `""` | Overrides the GPU image tag whose default is the chart appVersion |
 | image.web | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/lexfrei/obico-web","tag":""}` | Web application image (Django + Celery) |
 | image.web.tag | string | `""` | Overrides the image tag whose default is the chart appVersion |
 | imagePullSecrets | list | `[]` |  |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"obico.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["obico.example.com"],"secretName":"obico-tls"}]}` | Ingress configuration |
-| mlApi | object | `{"command":["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"],"enabled":true,"replicaCount":1,"resources":{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{}}` | ML inference API (AI failure detection). Heavy image; can be disabled. |
+| mlApi | object | `{"command":["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"],"enabled":true,"externalHost":"","gpu":false,"gpuResources":{"nvidia.com/gpu":1},"replicaCount":1,"resources":{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{}}` | ML inference API (AI failure detection). Can be disabled. |
 | mlApi.command | list | `["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"]` | Command for the gunicorn inference server |
 | mlApi.enabled | bool | `true` | Deploy the ML inference API |
+| mlApi.externalHost | string | `""` | External ML inference API URL (scheme://host:port), used when enabled is false. Obico still calls the ML API for prints that have AI detection on, so if you disable the bundled ml-api, either point this at an external instance or make sure AI detection is off on every printer — otherwise picture uploads that request detection will error. |
+| mlApi.gpu | bool | `false` | Run the CUDA (GPU) inference image instead of the slim CPU default. When true the ml-api container uses image.mlApi.gpu and requests the accelerator from gpuResources; requires an NVIDIA GPU and device plugin on the node. The CPU image works everywhere and is far smaller, so leave this false unless you actually have a GPU. |
+| mlApi.gpuResources | object | `{"nvidia.com/gpu":1}` | Accelerator resources merged into the ml-api container limits when gpu is true. Adjust for non-NVIDIA or MIG / time-sliced GPUs (e.g. nvidia.com/mig-1g.5gb: 1). |
 | mlApi.replicaCount | int | `1` | Number of ml-api replicas |
 | mlApi.resources | object | `{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resource requests/limits for the ml-api container |
 | mlApi.securityContext | object | `{}` | Security context for the ml-api container. Left empty (image default = root) because the upstream CUDA-based ml-api image is not validated to run unprivileged (model cache and runtime expect root). Harden here once confirmed it runs as non-root in your environment. |
@@ -267,8 +282,8 @@ The trade-off is size: the CUDA layers make the `ml-api` image large (~3 GB comp
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use |
-| tasks | object | `{"command":["celery","-A","config","worker","--beat","-l","info","-c","2","-Q","realtime,celery"],"resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | Celery worker (runs in the same pod as the web server) |
-| tasks.command | list | `["celery","-A","config","worker","--beat","-l","info","-c","2","-Q","realtime,celery"]` | Command for the Celery worker with beat scheduler |
+| tasks | object | `{"command":["celery","-A","config","worker","--beat","--schedule","/data/celerybeat-schedule","-l","info","-c","2","-Q","realtime,celery"],"resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}}` | Celery worker (runs in the same pod as the web server) |
+| tasks.command | list | `["celery","-A","config","worker","--beat","--schedule","/data/celerybeat-schedule","-l","info","-c","2","-Q","realtime,celery"]` | Command for the Celery worker with the embedded beat scheduler. The beat schedule DB is written under /data (a writable, persistent volume) because the container runs as non-root and the image's /app is not writable; the default (celerybeat-schedule in the working directory) would crash beat. |
 | tasks.resources | object | `{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"100m","memory":"256Mi"}}` | Resource requests/limits for the tasks container |
 | tolerations | list | `[]` |  |
 | web | object | `{"command":["daphne","-b","0.0.0.0","-p","3334","config.routing:application"],"resources":{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":"250m","memory":"512Mi"}}}` | Web pod configuration (server + tasks containers, plus init containers) |

--- a/charts/obico/README.md.gotmpl
+++ b/charts/obico/README.md.gotmpl
@@ -31,7 +31,7 @@ The container images are built from obico-server source and published to GHCR ([
 
 ## Images and auto-update
 
-Obico upstream does not publish ready-to-run images, so they are built from source in a separate repository. Both `obico-web` and `obico-ml-api` are built from one obico commit and share a single calendar-version tag (the chart `appVersion`). Renovate watches the image tag and bumps the chart automatically.
+Obico upstream does not publish ready-to-run images, so they are built from source in a separate repository. Three images — `obico-web`, `obico-ml-api-cpu` and `obico-ml-api-gpu` — are built from one obico commit and share a single calendar-version tag (the chart `appVersion`). Renovate watches the image tag and bumps the chart automatically.
 
 {{ template "chart.maintainersSection" . }}
 
@@ -170,15 +170,24 @@ The web pod runs a single replica because the default SQLite database lives on a
 
 The bundled Redis (`redis.enabled: true`) is a minimal, **unauthenticated** single instance intended for in-cluster use only. Do not expose it outside the cluster. For a hardened or shared Redis, set `redis.enabled: false` and point `redis.externalUrl` at your own instance.
 
-## ML inference image (GPU / CPU)
+## ML inference image (CPU / GPU)
 
-The `ml-api` service currently uses a single image with GPU support baked in — it is built on the upstream CUDA base, so the CUDA / cuDNN runtime libraries ship inside it.
+The `ml-api` service ships as two images built from the same source:
 
-On a node without a GPU it transparently falls back to CPU inference: Obico tries the GPU model first, the CUDA load fails (the NVIDIA driver libraries are not present in the image), and it drops to the CPU path automatically. No configuration is required — it just works, only slower than on a GPU.
+* **CPU (default)** — `obico-ml-api-cpu`, a slim image that runs failure detection on the CPU via ONNX Runtime. No CUDA layers and no NVIDIA toolchain, an order of magnitude smaller than the GPU image (~1 GB vs ~7–8 GB on disk). This is what the chart deploys by default and it runs on any node.
+* **GPU** — `obico-ml-api-gpu`, the CUDA image for NVIDIA GPU inference. Much larger, since the CUDA / cuDNN runtime ships inside it.
 
-On a node with an NVIDIA GPU (device plugin and container runtime configured), schedule `ml-api` there via `nodeSelector` / `tolerations` and an `nvidia.com/gpu` resource limit, and it uses the GPU.
+Most self-hosted deployments run CPU inference and should keep the default. Enable the GPU image only if you have an NVIDIA GPU with the device plugin configured:
 
-The trade-off is size: the CUDA layers make the `ml-api` image large (~3 GB compressed), and on a CPU-only deployment that weight is never exercised. If image size matters for you, open an issue and a slimmer CPU-only image variant will be added. To skip AI failure detection entirely, set `mlApi.enabled: false`.
+```yaml
+mlApi:
+  gpu: true
+  # Adjust for non-NVIDIA / MIG / time-sliced GPUs.
+  gpuResources:
+    nvidia.com/gpu: 1
+```
+
+When `gpu` is true the chart uses the CUDA image and adds `gpuResources` to the container limits, so the scheduler places the pod on a GPU node. To skip AI failure detection entirely, set `mlApi.enabled: false` — but note that Obico still calls the ML API for any printer with detection enabled, so also turn detection off per printer or point `mlApi.externalHost` at an external instance, otherwise those picture uploads will error.
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/obico/templates/NOTES.txt
+++ b/charts/obico/templates/NOTES.txt
@@ -44,7 +44,14 @@ Then open: http://localhost:{{ .Values.service.web.port }}
 {{- end }}
 
 First-run setup:
-  1. Create an admin account by signing up in the web UI (first user is staff).
+  1. Create an admin account (self-service signup is disabled by default):
+
+       kubectl --namespace {{ .Release.Namespace }} exec -it \
+         deploy/{{ include "obico.fullname" . }}-web -c server -- \
+         python manage.py createsuperuser
+
+     To allow open registration instead, set
+     obico.extraEnv.ACCOUNT_ALLOW_SIGN_UP="True".
   2. Configure the public URL under Settings if serving behind a proxy.
 {{- if not .Values.obico.siteUsesHttps }}
   3. When serving over HTTPS, set obico.siteUsesHttps=true and upgrade.

--- a/charts/obico/templates/_helpers.tpl
+++ b/charts/obico/templates/_helpers.tpl
@@ -7,18 +7,20 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
+Truncate at 56, not 63: templates append component suffixes (the longest is
+"-ml-api", 7 chars) to this base name, and the result must stay within the
+63-char Kubernetes DNS label limit. If the release name contains the chart
+name it is used as the full name.
 */}}
 {{- define "obico.fullname" -}}
 {{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- .Values.fullnameOverride | trunc 56 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- .Release.Name | trunc 56 | trimSuffix "-" }}
 {{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- printf "%s-%s" .Release.Name $name | trunc 56 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/obico/templates/configmap.yaml
+++ b/charts/obico/templates/configmap.yaml
@@ -14,6 +14,8 @@ data:
   REDIS_URL: {{ include "obico.redisUrl" . | quote }}
   {{- if .Values.mlApi.enabled }}
   ML_API_HOST: {{ printf "http://%s-ml-api:%v" (include "obico.fullname" .) .Values.service.mlApi.port | quote }}
+  {{- else if .Values.mlApi.externalHost }}
+  ML_API_HOST: {{ .Values.mlApi.externalHost | quote }}
   {{- end }}
   INTERNAL_MEDIA_HOST: {{ printf "http://%s-web:%v" (include "obico.fullname" .) .Values.service.web.port | quote }}
   {{- if and (not .Values.database.existingSecret) (not .Values.database.host) }}

--- a/charts/obico/templates/deployment-ml-api.yaml
+++ b/charts/obico/templates/deployment-ml-api.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.mlApi.enabled }}
+{{- $mlImage := ternary .Values.image.mlApi.gpu .Values.image.mlApi.cpu .Values.mlApi.gpu -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +34,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: ml-api
-          image: "{{ .Values.image.mlApi.repository }}:{{ .Values.image.mlApi.tag | default .Chart.AppVersion }}"
+          image: "{{ $mlImage.repository }}:{{ $mlImage.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.mlApi.pullPolicy }}
           {{- with .Values.mlApi.securityContext }}
           securityContext:
@@ -65,7 +66,15 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 6
           resources:
-            {{- toYaml .Values.mlApi.resources | nindent 12 }}
+            {{- $resources := deepCopy .Values.mlApi.resources }}
+            {{- if .Values.mlApi.gpu }}
+            {{- $limits := $resources.limits | default dict }}
+            {{- range $name, $qty := .Values.mlApi.gpuResources }}
+            {{- $_ := set $limits $name $qty }}
+            {{- end }}
+            {{- $_ := set $resources "limits" $limits }}
+            {{- end }}
+            {{- toYaml $resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/obico/templates/deployment-web.yaml
+++ b/charts/obico/templates/deployment-web.yaml
@@ -43,10 +43,15 @@ spec:
           image: "{{ .Values.image.web.repository }}:{{ .Values.image.web.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.web.pullPolicy }}
           # Generates static assets into the shared static volume. Runs as root
-          # because the image's /app tree is owned by root.
+          # because the image's /app tree is owned by root, but still drops
+          # capabilities and blocks privilege escalation for defense in depth.
           securityContext:
             runAsUser: 0
             runAsGroup: 0
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           command:
             - python
             - manage.py
@@ -110,16 +115,19 @@ spec:
             failureThreshold: 6
           # static (emptyDir) holds collectstatic output; media (PVC) is mounted
           # nested at static_build/media so user uploads land on the PVC while
-          # static assets stay in the emptyDir. collectstatic writes only static,
-          # so nothing it produces is shadowed by the media PVC. The tasks
-          # container does not serve static and so does not mount it.
+          # static assets stay in the emptyDir. The parent (static) is listed
+          # before the nested child (media) so the media PVC is never shadowed by
+          # the static emptyDir, regardless of how the runtime orders the mounts.
+          # collectstatic writes only static, so nothing it produces is shadowed
+          # by the media PVC. The tasks container does not serve static and so
+          # does not mount it.
           volumeMounts:
             - name: data
               mountPath: /data
-            - name: media
-              mountPath: /app/static_build/media
             - name: static
               mountPath: /app/static_build
+            - name: media
+              mountPath: /app/static_build/media
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
         # Celery worker. Intentionally has no liveness probe: it shares this pod

--- a/charts/obico/templates/httproute.yaml
+++ b/charts/obico/templates/httproute.yaml
@@ -20,8 +20,11 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.httpRoute.rules }}
-    - matches:
-        {{- toYaml .matches | nindent 8 }}
+    -
+      {{- with .matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .filters }}
       filters:
         {{- toYaml . | nindent 8 }}
@@ -29,8 +32,8 @@ spec:
       backendRefs:
         - name: {{ include "obico.fullname" $ }}-web
           port: {{ $.Values.service.web.port }}
-          {{- with .weight }}
-          weight: {{ . }}
+          {{- if not (kindIs "invalid" .weight) }}
+          weight: {{ .weight }}
           {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/obico/tests/configmap_test.yaml
+++ b/charts/obico/tests/configmap_test.yaml
@@ -170,12 +170,21 @@ tests:
           path: data.CSRF_TRUSTED_ORIGINS
           value: '["https://custom.example.com"]'
 
-  - it: should omit ML_API_HOST when ml-api is disabled
+  - it: should omit ML_API_HOST when ml-api is disabled and no external host is set
     set:
       mlApi.enabled: false
     asserts:
       - notExists:
           path: data.ML_API_HOST
+
+  - it: should point ML_API_HOST at externalHost when ml-api is disabled
+    set:
+      mlApi.enabled: false
+      mlApi.externalHost: http://ml-api.example:3333
+    asserts:
+      - equal:
+          path: data.ML_API_HOST
+          value: http://ml-api.example:3333
 
   - it: should reject CSRF_TRUSTED_ORIGINS in extraEnv
     set:

--- a/charts/obico/tests/deployment_ml_api_test.yaml
+++ b/charts/obico/tests/deployment_ml_api_test.yaml
@@ -19,11 +19,44 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should use the ml-api image
+  - it: should use the slim CPU ml-api image by default
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: '^ghcr\.io/lexfrei/obico-ml-api:'
+          pattern: '^ghcr\.io/lexfrei/obico-ml-api-cpu:'
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+
+  - it: should use the CUDA image and request a GPU when gpu is enabled
+    set:
+      mlApi.gpu: true
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/lexfrei/obico-ml-api-gpu:'
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 1
+
+  - it: should honor a custom gpu resource name
+    set:
+      mlApi.gpu: true
+      mlApi.gpuResources:
+        nvidia.com/mig-1g.5gb: 2
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/mig-1g.5gb"]
+          value: 2
+
+  - it: should keep the name within 63 chars for a long release name
+    # ml-api carries the longest component suffix (-ml-api); the fullname helper
+    # reserves room so the DNS label stays valid even at a max-length release name.
+    release:
+      name: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    asserts:
+      - matchRegex:
+          path: metadata.name
+          pattern: '^.{1,63}$'
 
   - it: should expose port 3333
     asserts:

--- a/charts/obico/tests/deployment_web_test.yaml
+++ b/charts/obico/tests/deployment_web_test.yaml
@@ -45,12 +45,18 @@ tests:
           path: spec.template.spec.initContainers[1].name
           value: migrate
 
-  - it: should run collectstatic as root
+  - it: should run collectstatic as root but drop capabilities and block privilege escalation
     template: deployment-web.yaml
     asserts:
       - equal:
           path: spec.template.spec.initContainers[0].securityContext.runAsUser
           value: 0
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop
+          content: ALL
 
   - it: should have server and tasks containers
     template: deployment-web.yaml
@@ -98,6 +104,31 @@ tests:
       - contains:
           path: spec.template.spec.containers[1].command
           content: celery
+
+  - it: should write the celery beat schedule to the writable /data volume
+    # The container runs as non-root and /app is read-only, so beat's default
+    # celerybeat-schedule (in the working directory) would crash the worker.
+    template: deployment-web.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].command
+          content: --schedule
+      - contains:
+          path: spec.template.spec.containers[1].command
+          content: /data/celerybeat-schedule
+
+  - it: should mount the static parent before the nested media child on the server
+    # static (/app/static_build, emptyDir) must precede media
+    # (/app/static_build/media, PVC) so the parent mount never shadows the media
+    # PVC — otherwise uploads land in the emptyDir and are lost on restart.
+    template: deployment-web.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /app/static_build
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[2].mountPath
+          value: /app/static_build/media
 
   - it: should load env from the ConfigMap and Secret
     template: deployment-web.yaml

--- a/charts/obico/tests/httproute_test.yaml
+++ b/charts/obico/tests/httproute_test.yaml
@@ -136,6 +136,38 @@ tests:
           path: spec.rules[0].backendRefs[0].weight
           value: 100
 
+  - it: should preserve a zero backendRef weight (drain)
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - matches:
+            - path:
+                type: PathPrefix
+                value: /
+          weight: 0
+    asserts:
+      - equal:
+          path: spec.rules[0].backendRefs[0].weight
+          value: 0
+
+  - it: should omit matches for a catch-all rule
+    # Gateway API treats an absent matches field as "match all"; rendering
+    # matches: null would fail the HTTPRoute CRD schema (matches must be a list).
+    set:
+      httpRoute.enabled: true
+      httpRoute.rules:
+        - filters:
+            - type: RequestHeaderModifier
+              requestHeaderModifier:
+                add:
+                  - name: X-Test
+                    value: "1"
+    asserts:
+      - notExists:
+          path: spec.rules[0].matches
+      - exists:
+          path: spec.rules[0].backendRefs
+
   - it: should support multiple rules
     set:
       httpRoute.enabled: true

--- a/charts/obico/tests/notes_test.yaml
+++ b/charts/obico/tests/notes_test.yaml
@@ -23,3 +23,12 @@ tests:
     asserts:
       - matchRegexRaw:
           pattern: 'Database: postgresql://obico@obico-db-pooler:5432/obico \(password from secret obico-db-app\)'
+
+  - it: should tell the operator to create the admin via createsuperuser
+    asserts:
+      # Self-service signup is disabled by default and there is no first-user-is-staff
+      # logic, so NOTES must point at manage.py createsuperuser, not the web UI.
+      - matchRegexRaw:
+          pattern: 'python manage\.py createsuperuser'
+      - notMatchRegexRaw:
+          pattern: 'signing up in the web UI'

--- a/charts/obico/values.schema.json
+++ b/charts/obico/values.schema.json
@@ -28,21 +28,41 @@
         "mlApi": {
           "type": "object",
           "properties": {
-            "repository": {
-              "type": "string",
-              "description": "ML API image repository"
-            },
             "pullPolicy": {
               "type": "string",
               "enum": ["Always", "IfNotPresent", "Never"],
               "description": "ML API image pull policy"
             },
-            "tag": {
-              "type": "string",
-              "description": "Overrides the ml-api image tag whose default is the chart appVersion"
+            "cpu": {
+              "type": "object",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "description": "CPU-only ml-api image repository"
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Overrides the CPU ml-api image tag whose default is the chart appVersion"
+                }
+              },
+              "required": ["repository"]
+            },
+            "gpu": {
+              "type": "object",
+              "properties": {
+                "repository": {
+                  "type": "string",
+                  "description": "CUDA (GPU) ml-api image repository"
+                },
+                "tag": {
+                  "type": "string",
+                  "description": "Overrides the GPU ml-api image tag whose default is the chart appVersion"
+                }
+              },
+              "required": ["repository"]
             }
           },
-          "required": ["repository", "pullPolicy"]
+          "required": ["pullPolicy", "cpu", "gpu"]
         }
       },
       "required": ["web", "mlApi"]
@@ -181,6 +201,21 @@
         "enabled": {
           "type": "boolean",
           "description": "Deploy the ML inference API"
+        },
+        "externalHost": {
+          "type": "string",
+          "description": "External ML inference API URL, used when enabled is false"
+        },
+        "gpu": {
+          "type": "boolean",
+          "description": "Run the CUDA (GPU) ml-api image and request the accelerator; defaults to the slim CPU image"
+        },
+        "gpuResources": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["integer", "string"]
+          },
+          "description": "Accelerator resources merged into the ml-api container limits when gpu is true"
         },
         "replicaCount": {
           "type": "integer",

--- a/charts/obico/values.yaml
+++ b/charts/obico/values.yaml
@@ -3,8 +3,8 @@
 # worker, an ML inference API and Redis. The web and tasks containers share a
 # single pod so they can share the SQLite database on a ReadWriteOnce volume.
 
-# -- Container images. Built from obico-server source and published to GHCR.
-# Both images share the chart appVersion tag (one obico commit -> one tag).
+# -- Container images. Built from obico-server source and published to GHCR;
+# all share the chart appVersion tag (one obico commit -> one tag).
 image:
   # -- Web application image (Django + Celery)
   web:
@@ -12,12 +12,21 @@ image:
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the chart appVersion
     tag: ""
-  # -- ML inference API image (failure detection)
+  # -- ML inference API images. Two variants are published from the same source:
+  # a slim CPU-only image (default) and a CUDA image for GPU inference.
+  # mlApi.gpu selects which one runs; configure each variant independently.
   mlApi:
-    repository: ghcr.io/lexfrei/obico-ml-api
     pullPolicy: IfNotPresent
-    # -- Overrides the image tag whose default is the chart appVersion
-    tag: ""
+    # -- CPU-only inference image (slim). Used when mlApi.gpu is false.
+    cpu:
+      repository: ghcr.io/lexfrei/obico-ml-api-cpu
+      # -- Overrides the CPU image tag whose default is the chart appVersion
+      tag: ""
+    # -- CUDA inference image (large). Used when mlApi.gpu is true.
+    gpu:
+      repository: ghcr.io/lexfrei/obico-ml-api-gpu
+      # -- Overrides the GPU image tag whose default is the chart appVersion
+      tag: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -110,13 +119,18 @@ web:
 
 # -- Celery worker (runs in the same pod as the web server)
 tasks:
-  # -- Command for the Celery worker with beat scheduler
+  # -- Command for the Celery worker with the embedded beat scheduler. The beat
+  # schedule DB is written under /data (a writable, persistent volume) because
+  # the container runs as non-root and the image's /app is not writable; the
+  # default (celerybeat-schedule in the working directory) would crash beat.
   command:
     - celery
     - -A
     - config
     - worker
     - --beat
+    - --schedule
+    - /data/celerybeat-schedule
     - -l
     - info
     - -c
@@ -132,10 +146,26 @@ tasks:
       memory: "512Mi"
       cpu: "500m"
 
-# -- ML inference API (AI failure detection). Heavy image; can be disabled.
+# -- ML inference API (AI failure detection). Can be disabled.
 mlApi:
   # -- Deploy the ML inference API
   enabled: true
+  # -- External ML inference API URL (scheme://host:port), used when enabled is
+  # false. Obico still calls the ML API for prints that have AI detection on, so
+  # if you disable the bundled ml-api, either point this at an external instance
+  # or make sure AI detection is off on every printer — otherwise picture uploads
+  # that request detection will error.
+  externalHost: ""
+  # -- Run the CUDA (GPU) inference image instead of the slim CPU default. When
+  # true the ml-api container uses image.mlApi.gpu and requests the accelerator
+  # from gpuResources; requires an NVIDIA GPU and device plugin on the node. The
+  # CPU image works everywhere and is far smaller, so leave this false unless you
+  # actually have a GPU.
+  gpu: false
+  # -- Accelerator resources merged into the ml-api container limits when gpu is
+  # true. Adjust for non-NVIDIA or MIG / time-sliced GPUs (e.g. nvidia.com/mig-1g.5gb: 1).
+  gpuResources:
+    nvidia.com/gpu: 1
   # -- Number of ml-api replicas
   replicaCount: 1
   # -- Command for the gunicorn inference server


### PR DESCRIPTION
## What

Splits the ml-api image into a slim CPU default and a CUDA GPU variant, and backports robustness fixes to the obico chart.

- `mlApi.gpu` selects the image: CPU (`obico-ml-api-cpu`, ~1 GB on disk, default) vs CUDA (`obico-ml-api-gpu`). `image.mlApi` now nests `cpu`/`gpu`. **Breaking:** `image.mlApi.repository`/`.tag` and the old `obico-ml-api` image are replaced by `obico-ml-api-cpu` / `obico-ml-api-gpu`.
- `mlApi.externalHost` keeps `ML_API_HOST` set when the bundled ml-api is disabled.
- Fixes: Celery beat schedule → `/data` (was crashing under non-root); static/media volumeMount order (uploads shadowed and lost on restart); fullname truncation reserves room for suffixes (long release names); HTTPRoute `weight: 0` and catch-all `matches`; drop capabilities on the collectstatic init container; NOTES admin creation via `manage.py createsuperuser`.

## Depends on

The `obico-ml-api-cpu` / `obico-ml-api-gpu` images are produced by lexfrei/images#10 (merged) — its build publishes them to GHCR before this chart bump goes live.

## Testing

`helm lint` clean, 122 `helm-unittest` cases, `values.schema.json` validation, README generated by `helm-docs`.
