### PR TITLE
fix(spoolman): match the deployment test to the v0.24.0 image tag

### DIFF
--- a/charts/spoolman/Chart.yaml
+++ b/charts/spoolman/Chart.yaml
@@ -2,6 +2,8 @@ annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: Update ghcr.io/donkie/spoolman docker tag to v0.24.0
+    - kind: fixed
+      description: Update the deployment unit test to match the v0.24.0 image tag
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -15,7 +17,7 @@ apiVersion: v2
 name: spoolman
 description: Spoolman filament spool inventory management for 3D printing, packaged for Kubernetes
 type: application
-version: "0.2.1"
+version: "0.2.2"
 # renovate: datasource=docker depName=ghcr.io/donkie/spoolman
 appVersion: "0.24.0"
 icon: https://raw.githubusercontent.com/Donkie/Spoolman/master/client/public/pwa-512x512.png

--- a/charts/spoolman/tests/deployment_test.yaml
+++ b/charts/spoolman/tests/deployment_test.yaml
@@ -19,7 +19,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/donkie/spoolman:0.23.1"
+          value: "ghcr.io/donkie/spoolman:0.24.0"
 
   - it: should allow overriding the image tag
     set:


### PR DESCRIPTION
The image tag was bumped to v0.24.0 (#233) but the "should use the appVersion as the default image tag" test still expected v0.23.1, so the unit suite failed and blocked chart publishing. Sync the expected tag and bump the chart version to 0.2.2.