### PR TITLE
fix(spoolman): make the image-tag test survive Renovate appVersion bumps

### DIFF
--- a/charts/spoolman/Chart.yaml
+++ b/charts/spoolman/Chart.yaml
@@ -1,9 +1,7 @@
 annotations:
   artifacthub.io/changes: |-
-    - kind: changed
-      description: Update ghcr.io/donkie/spoolman docker tag to v0.24.0
     - kind: fixed
-      description: Update the deployment unit test to match the v0.24.0 image tag
+      description: Pin the appVersion in the image-tag unit test so Renovate bumps no longer break it
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Chart Repository
@@ -17,7 +15,7 @@ apiVersion: v2
 name: spoolman
 description: Spoolman filament spool inventory management for 3D printing, packaged for Kubernetes
 type: application
-version: "0.2.2"
+version: "0.2.3"
 # renovate: datasource=docker depName=ghcr.io/donkie/spoolman
 appVersion: "0.24.0"
 icon: https://raw.githubusercontent.com/Donkie/Spoolman/master/client/public/pwa-512x512.png

--- a/charts/spoolman/README.md
+++ b/charts/spoolman/README.md
@@ -1,6 +1,6 @@
 # spoolman
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.24.0](https://img.shields.io/badge/AppVersion-0.24.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -36,12 +36,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install spoolman \
   oci://ghcr.io/lexfrei/charts/spoolman \
-  --version 0.2.1
+  --version 0.2.3
 
 # Install with custom values
 helm install spoolman \
   oci://ghcr.io/lexfrei/charts/spoolman \
-  --version 0.2.1 \
+  --version 0.2.3 \
   --values values.yaml
 ```
 
@@ -51,7 +51,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/spoolman:0.2.1 \
+  ghcr.io/lexfrei/charts/spoolman:0.2.3 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```

--- a/charts/spoolman/tests/deployment_test.yaml
+++ b/charts/spoolman/tests/deployment_test.yaml
@@ -16,10 +16,15 @@ tests:
           value: RELEASE-NAME-spoolman
 
   - it: should use the appVersion as the default image tag
+    # Pin the appVersion locally so a Renovate bump of the real Chart.yaml
+    # appVersion cannot break this test. It verifies the templating (image tag
+    # defaults to the appVersion), not the current version string.
+    chart:
+      appVersion: "9.9.9"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/donkie/spoolman:0.24.0"
+          value: "ghcr.io/donkie/spoolman:9.9.9"
 
   - it: should allow overriding the image tag
     set:


### PR DESCRIPTION
## Root cause

The `should use the appVersion as the default image tag` test asserted the exact tag `ghcr.io/donkie/spoolman:<appVersion>`. Renovate's `update-renovate-pr` automation syncs Chart.yaml + changelog + README + version on an appVersion bump, but it does not touch tests — so every bump broke this unit test. Because `lint-test (charts/spoolman)` is not a required status check, the broken PR then auto-merged, which in turn failed `publish-oci` (it validates all charts) and left the README out of date after the manual recovery.

## Fix

Pin the appVersion inside the test via helm-unittest's `chart:` override so it validates the templating (image tag defaults to appVersion) without depending on the volatile version string. Verified: bumping the real appVersion no longer changes the test result. Also regenerates the README (it had drifted to the previous version).