### PR TITLE
ci: add an aggregate all-charts-passed required status check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -257,3 +257,29 @@ jobs:
             fi
           done
           exit $rc
+
+  # Single aggregate check to require in branch protection instead of a
+  # hand-maintained per-chart list. It gates the whole lint-test matrix (every
+  # chart, and any newly added one) plus the issue-template check, so no chart
+  # can merge red and new charts are covered automatically.
+  all-charts-passed:
+    name: all-charts-passed
+    if: always()
+    needs: [lint-test, validate-issue-templates]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all chart checks succeeded
+        run: |
+          # A matrix job resolves to 'success' only when every leg passed;
+          # 'skipped' means nothing needed running (e.g. no charts changed).
+          for job in "lint-test:${{ needs.lint-test.result }}" \
+                     "validate-issue-templates:${{ needs.validate-issue-templates.result }}"; do
+            name="${job%%:*}"
+            result="${job##*:}"
+            echo "${name}: ${result}"
+            if [ "${result}" != "success" ] && [ "${result}" != "skipped" ]; then
+              echo "::error::${name} did not pass"
+              exit 1
+            fi
+          done
+          echo "All required chart checks passed."


### PR DESCRIPTION
## Why

Branch protection currently requires a hand-maintained list of five `lint-test (charts/X)` contexts (cloudflare-tunnel, me-site, system-upgrade-controller, transmission, vipalived). The other charts — including obico and spoolman — are **not** required, so a PR that breaks one of them (e.g. a Renovate bump breaking a unit test) can auto-merge and land breakage on master. That is exactly how the recent spoolman unit-test failure reached master and then blocked `publish-oci`.

## What

Add a single `all-charts-passed` job that depends on the whole `lint-test` matrix (every chart, and any added later) plus the issue-template check, and fails unless they all pass. After this merges, branch protection is switched to require the single `all-charts-passed` context instead of the five hard-coded charts — no chart can merge red, and new charts are covered automatically.