### PR TITLE
feat(me-site): add liveness and readiness probes

### DIFF
--- a/charts/me-site/Chart.yaml
+++ b/charts/me-site/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: me-site
 description: A Helm chart for the Me-Site application
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: 1.0.0
 maintainers:
   - name: lexfrei
@@ -11,7 +11,5 @@ maintainers:
 annotations:
   artifacthub.io/changes: |-
     - kind: added
-      description: "automountServiceAccountToken value to control API token automounting"
-    - kind: changed
-      description: "Do not automount the ServiceAccount API token by default, as me-site does not use the Kubernetes API"
+      description: "livenessProbe and readinessProbe values, enabled by default with an HTTP GET on /"
 kubeVersion: '>=1.19.0-0'

--- a/charts/me-site/README.md
+++ b/charts/me-site/README.md
@@ -1,6 +1,6 @@
 # me-site
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 ## 📊 Status & Metrics
 
@@ -29,12 +29,12 @@ This chart is published to GitHub Container Registry (GHCR) as an OCI artifact.
 # Install from GHCR
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.6.0
+  --version 0.7.0
 
 # Install with custom values
 helm install me-site \
   oci://ghcr.io/lexfrei/charts/me-site \
-  --version 0.6.0 \
+  --version 0.7.0 \
   --values values.yaml
 ```
 
@@ -44,7 +44,7 @@ This chart is signed with [cosign](https://github.com/sigstore/cosign) using key
 
 ```bash
 cosign verify \
-  ghcr.io/lexfrei/charts/me-site:0.6.0 \
+  ghcr.io/lexfrei/charts/me-site:0.7.0 \
   --certificate-identity "https://github.com/lexfrei/charts/.github/workflows/publish-oci.yaml@refs/heads/master" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
@@ -78,6 +78,7 @@ helm delete me-site
 | ingress.hosts[0].paths[0].path | string | `"/"` |  |
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
+| livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/","port":"web"},"initialDelaySeconds":10,"periodSeconds":20,"timeoutSeconds":3}` | Liveness probe. me-site serves a static site, so an HTTP GET on / catches a hung or crashed web server and restarts the pod. Set to null/{} to disable. |
 | networkPolicy.egress | list | `[]` |  |
 | networkPolicy.enabled | bool | `false` |  |
 | networkPolicy.ingress | list | `[]` |  |
@@ -88,6 +89,7 @@ helm delete me-site
 | podSecurityContext.runAsNonRoot | bool | `true` |  |
 | podSecurityContext.runAsUser | int | `65534` |  |
 | podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| readinessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/","port":"web"},"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":3}` | Readiness probe. Removes the pod from the Service endpoints while it cannot serve, so a rolling update never routes to a not-yet-ready pod. Set to null/{} to disable. |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | string | `"100m"` |  |
 | resources.limits.memory | string | `"50Mi"` |  |

--- a/charts/me-site/templates/deployment.yaml
+++ b/charts/me-site/templates/deployment.yaml
@@ -39,3 +39,11 @@ spec:
           ports:
             - name: web
               containerPort: {{ .Values.containerPort }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/me-site/tests/probe_test.yaml
+++ b/charts/me-site/tests/probe_test.yaml
@@ -1,0 +1,28 @@
+suite: probe tests
+templates:
+  - deployment.yaml
+tests:
+  - it: should render liveness and readiness probes by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: web
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: web
+
+  - it: should omit probes when disabled
+    set:
+      livenessProbe: null
+      readinessProbe: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe

--- a/charts/me-site/values.schema.json
+++ b/charts/me-site/values.schema.json
@@ -77,6 +77,14 @@
     "servicePort": {
       "type": "integer"
     },
+    "livenessProbe": {
+      "type": ["object", "null"],
+      "description": "Liveness probe for the me-site container. Set to null/{} to disable."
+    },
+    "readinessProbe": {
+      "type": ["object", "null"],
+      "description": "Readiness probe for the me-site container. Set to null/{} to disable."
+    },
     "onionService": {
       "type": "object",
       "properties": {

--- a/charts/me-site/values.yaml
+++ b/charts/me-site/values.yaml
@@ -14,6 +14,24 @@ resources:
     memory: 50Mi
 containerPort: 8080
 servicePort: 8080
+# -- Liveness probe. me-site serves a static site, so an HTTP GET on / catches a hung or crashed web server and restarts the pod. Set to null/{} to disable.
+livenessProbe:
+  httpGet:
+    path: /
+    port: web
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 3
+  failureThreshold: 3
+# -- Readiness probe. Removes the pod from the Service endpoints while it cannot serve, so a rolling update never routes to a not-yet-ready pod. Set to null/{} to disable.
+readinessProbe:
+  httpGet:
+    path: /
+    port: web
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
 onionService:
   enabled: true
   backends: 1


### PR DESCRIPTION
## Description

me-site shipped no liveness or readiness probes, so a hung or crashed web server was never restarted and a broken pod stayed in the Service endpoints (a rolling update could route to a not-yet-ready pod). This adds configurable `livenessProbe` and `readinessProbe`, enabled by default with an HTTP GET on `/` (me-site serves a static site). Both are full probe specs in values, so any field can be overridden; set either to `null`/`{}` to disable it.

Chart: `me-site` 0.6.0 -> 0.7.0.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

### Required for chart changes

- [x] Chart version has been bumped in `Chart.yaml`
- [x] **`Chart.yaml` annotations updated with changelog entries** (`artifacthub.io/changes`)
- [x] `values.schema.json` has been updated (if new values were added)
- [x] `README.md` has been updated (if new values were added)
- [x] All new values have proper descriptions/comments
- [x] Tests have been added/updated in `tests/` directory
- [x] All tests pass locally (`helm unittest charts/me-site`)
- [x] Schema validation passes (`check-jsonschema --schemafile charts/me-site/values.schema.json charts/me-site/values.yaml`)
- [x] Helm lint passes (`helm lint charts/me-site`)

### If adding new templates

- [x] Templates follow Helm best practices
- [x] Templates use proper indentation (`nindent` instead of `indent`)
- [x] Conditional rendering uses `{{- if }}` to control whitespace

### If modifying existing functionality

- [x] Changes are backward compatible OR breaking changes are documented
- [ ] Default values maintain existing behavior

## Additional context

The probes render by default (previously there were none), so "default values maintain existing behavior" is intentionally left unchecked. This is a deliberate reliable-by-default choice: me-site serves a static site, so an HTTP GET on `/` is a safe, meaningful health check that returns 200 for a healthy pod. Anyone who wants no probes can set `livenessProbe: null` / `readinessProbe: null`.
