### PR TITLE
fix(ci): report the aggregate check on dispatched runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -267,8 +267,11 @@ jobs:
     if: always()
     needs: [lint-test, validate-issue-templates]
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Verify all chart checks succeeded
+        id: verify
         run: |
           # A matrix job resolves to 'success' only when every leg passed;
           # 'skipped' means nothing needed running (e.g. no charts changed).
@@ -283,3 +286,29 @@ jobs:
             fi
           done
           echo "All required chart checks passed."
+
+      # A dispatched run executes on the default branch, so the check run this
+      # job produces is attached to master rather than to the commit under test
+      # — and this is the context branch protection requires. Without an
+      # explicit status the PR waits on a check that will never report: the
+      # per-chart statuses go green and the merge box stays blocked forever.
+      # That is the whole reason the bot's own commits deadlock the PR they fix.
+      - name: Publish the aggregate status to the dispatched commit
+        if: always() && github.event_name == 'repository_dispatch'
+        run: |
+          if [ "${{ steps.verify.outcome }}" = "success" ]; then
+            state=success
+            description="All required chart checks passed"
+          else
+            state=failure
+            description="Some chart checks failed"
+          fi
+
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.client_payload.sha }}" \
+            --method POST \
+            --field state="$state" \
+            --field context="all-charts-passed" \
+            --field description="$description" \
+            --field target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

Renovate PRs here deadlock, and the update job is what puts them there.

The sequence repeats on every chart bump. Renovate changes `appVersion`, which leaves README stale, so lint-test fails. The update job then regenerates the docs, bumps the chart version and pushes onto the PR branch. That push is made with `GITHUB_TOKEN`, so the `pull_request` runs that follow come back `action_required` and never execute. The job already works around this by retesting through `repository_dispatch`, and that part works: the dispatched run publishes each `lint-test (charts/...)` status onto the right commit.

What it never published is `all-charts-passed`, which is the context branch protection actually requires. A dispatched run executes on the default branch, so the check run that job produces lands on master rather than on the commit under test. The PR the bot just fixed is left waiting on a check that cannot report. Three PRs are sitting like that now, all green, review approved, merge blocked.

So the aggregate status is now posted explicitly for dispatched runs, the same way the per-chart ones already were.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart version bump

## Checklist

### Required for all PRs

- [x] I have tested these changes locally
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

`actionlint` passes on the changed workflow. The dispatch path itself can only be exercised on GitHub, so the first renovate PR after this merges is the real test.

### Required for chart changes

No chart changed here, this is workflow only.

### If adding new templates

No new templates.
